### PR TITLE
Introductie foutmeldingen via DOM elementen configureren

### DIFF
--- a/demo/vl-form-validation.html
+++ b/demo/vl-form-validation.html
@@ -26,7 +26,7 @@
 <body is="vl-body">
     <vl-demo-page data-vl-webcomponent="vl-form-validation" data-vl-link="https://overheid.vlaanderen.be/webuniversum/v3/documentation/forms/vl-ui-form-validation">
         <vl-demo data-vl-title="Formulier validatie">
-            <form id="form-met-error-messages-als-attribuut">
+            <form id="form-with-error-message-attributes">
                 <div is="vl-form-grid" data-vl-is-stacked data-vl-v-center>
                     <div is="vl-form-column" data-vl-size="3">
                         <label is="vl-form-label" for="input-voornaam" data-vl-block>Voornaam</label>
@@ -137,7 +137,7 @@
         </vl-demo>
 
         <vl-demo data-vl-title="Formulier validatie met succes melding">
-            <form id="form-met-succesmelding" data-vl-validate-form-success="true">
+            <form id="form-with-success" data-vl-validate-form-success="true">
                 <div is="vl-form-grid" data-vl-is-stacked data-vl-v-center>
                     <div is="vl-form-column" data-vl-size="3">
                         <label is="vl-form-label" for="input-1" data-vl-block>Voornaam</label>
@@ -203,7 +203,7 @@
         </vl-demo>
 
         <vl-demo data-vl-title="Formulier zonder validatie">
-            <form id="form-zonder-validatie" novalidate>
+            <form id="form-no-validation" novalidate>
                 <div is="vl-form-grid" data-vl-is-stacked data-vl-v-center>
                     <div is="vl-form-column" data-vl-size="3">
                         <label is="vl-form-message" for="naam">Naam</label>
@@ -221,7 +221,7 @@
         </vl-demo>
 
         <vl-demo data-vl-title="Formulier validatie met foutmelding in error-placeholder-element">
-            <form id="form-met-error-messages-via-placeholder">
+            <form id="form-with-error-message-elements">
                 <div is="vl-form-grid" data-vl-is-stacked data-vl-v-center>
                     <div is="vl-form-column" data-vl-size="3">
                         <label is="vl-form-label" for="input-voornaam" data-vl-block>Voornaam</label>

--- a/demo/vl-form-validation.html
+++ b/demo/vl-form-validation.html
@@ -130,7 +130,7 @@
                         <p is="vl-form-validation-message" error data-vl-error-id="validation-uuid-error"></p>
                     </div>
                     <div is="vl-form-column" data-vl-size="9" data-vl-push="3">
-                        <button is="vl-button">Formulier valideren</button>
+                        <button id="button-form1" is="vl-button">Formulier valideren</button>
                     </div>
                 </div>
             </form>
@@ -215,6 +215,92 @@
                         <button is="vl-button" onclick="document.querySelector('#form-3-input-1').value = null; document.querySelector('#form-3-input-1').dispatchEvent(new CustomEvent('change'));">
                             Leegmaken
                         </button>
+                    </div>
+                </div>
+            </form>
+        </vl-demo>
+
+        <vl-demo data-vl-title="Formulier validatie met foutmelding in error-placeholder-element">
+            <form id="form-4">
+                <div is="vl-form-grid" data-vl-is-stacked data-vl-v-center>
+                    <div is="vl-form-column" data-vl-size="3">
+                        <label is="vl-form-label" for="input-voornaam" data-vl-block>Voornaam</label>
+                    </div>
+                    <div is="vl-form-column" data-vl-size="9">
+                        <input id="input-form4-voornaam" is="vl-input-field-demo" placeholder="Jos" data-vl-block data-vl-required="true"
+                            data-vl-error-placeholder="validation-voornaam-error" />
+                        <p is="vl-form-validation-message" error data-vl-error-id="validation-voornaam-error">De voornaam is verplicht</p>
+                    </div>
+                   
+                    <div is="vl-form-column" data-vl-size="3">
+                        <label is="vl-form-label" for="input-email" data-vl-block>E-mailadres</label>
+                    </div>
+                    <div is="vl-form-column" data-vl-size="9">
+                        <input id="input-form4-email" is="vl-input-field-demo" placeholder="email@provider.com" data-vl-block type="email"
+                            data-vl-required="true" 
+                            data-vl-error-placeholder="validation-email-error" data-vl-validation-type="email" />
+                        <p is="vl-form-validation-message" error data-vl-error-id="validation-email-error">Een geldig 'E-mailadres' is verplicht</p>
+                    </div>
+                    <div is="vl-form-column" data-vl-size="3">
+                        <label is="vl-form-label" for="input-iban" data-vl-block>IBAN-nummer</label>
+                    </div>
+                    <div is="vl-form-column" data-vl-size="9">
+                        <input id="input-form4-iban" is="vl-input-field-demo" placeholder="BE00 0000 0000 0000" data-vl-block type="text"
+                            data-vl-required="true"
+                            data-vl-error-placeholder="validation-iban-error" data-vl-validation-type="iban" />
+                        <p is="vl-form-validation-message" error data-vl-error-id="validation-iban-error">Een geldig 'IBAN-nummer' is verplicht</p>
+                    </div>
+                    <div is="vl-form-column" data-vl-size="3">
+                        <label is="vl-form-label" for="input-telefoon" data-vl-block>Telefoonnummer</label>
+                    </div>
+                    <div is="vl-form-column" data-vl-size="9">
+                        <input id="input-form4-telefoon" is="vl-input-field-demo" placeholder="+32 0 000 00 00" data-vl-block type="phone"
+                            data-vl-required="true"
+                            data-vl-error-placeholder="validation-telefoon-error" data-vl-validation-type="phone" />
+                        <p is="vl-form-validation-message" error data-vl-error-id="validation-telefoon-error">Een geldig 'Telefoonnummer' is verplicht</p>
+                    </div>
+                    <div is="vl-form-column" data-vl-size="3">
+                        <label is="vl-form-label" for="input-rrn" data-vl-block>Rijksregisternummer</label>
+                    </div>
+                    <div is="vl-form-column" data-vl-size="9">
+                        <input id="input-form4-rrn" is="vl-input-field-demo" placeholder="11.22.33-444.55" data-vl-block type="text"
+                            data-vl-required="true"
+                            data-vl-error-placeholder="validation-rrn-error" data-vl-validation-type="rrn" />
+                        <p is="vl-form-validation-message" error data-vl-error-id="validation-rrn-error">Een geldig 'Rijksregisternummer' is verplicht</p>
+                    </div>
+                    <div is="vl-form-column" data-vl-size="3">
+                        <label is="vl-form-label" for="input-datum" data-vl-block>Geboortedatum</label>
+                    </div>
+                    <div is="vl-form-column" data-vl-size="9">
+                        <input id="input-form4-datum" is="vl-input-field-demo" placeholder="01.01.2020" data-vl-block type="text"
+                            data-vl-required="true"
+                            data-vl-error-placeholder="validation-datum-error" data-vl-validation-type="date" />
+                        <p is="vl-form-validation-message" error data-vl-error-id="validation-datum-error">Een geldige 'Geboortedatum' is verplicht/p>
+                    </div>
+                    <div is="vl-form-column" data-vl-size="3">
+                        <label is="vl-form-label" for="select-stad" data-vl-block>Stad</label>
+                    </div>
+                    <div is="vl-form-column" data-vl-size="9">
+                        <select id="select-form4-stad" is="vl-select-demo" data-vl-block name="validation-select"
+                            data-vl-required="true"
+                            data-vl-error-placeholder="validation-stad-error" data-vl-validation-type="select">
+                            <option placeholder value="">Kies een stad</option>
+                            <option value="Aalst">Aalst</option>
+                            <option value="Antwerpen">Antwerpen</option>
+                        </select>
+                        <p is="vl-form-validation-message" error data-vl-error-id="validation-stad-error">Een geldige 'Stad' is verplicht</p>
+                    </div>
+                    <div is="vl-form-column" data-vl-size="3">
+                        <label is="vl-form-label" for="input-uuid" data-vl-block>UUID</label>
+                    </div>
+                    <div is="vl-form-column" data-vl-size="9">
+                        <input id="input-form4-uuid" is="vl-input-field-demo" placeholder="1c6fa548-5eef-11eb-ae93-0242ac130002" data-vl-block type="text"
+                               data-vl-required="true"
+                               data-vl-error-placeholder="validation-uuid-error" data-vl-validation-type="uuid" />
+                        <p is="vl-form-validation-message" error data-vl-error-id="validation-uuid-error">Een geldige 'UUID' is verplicht</p>
+                    </div>
+                    <div is="vl-form-column" data-vl-size="9" data-vl-push="3">
+                        <button id="button-form4" is="vl-button">Formulier valideren</button>
                     </div>
                 </div>
             </form>

--- a/demo/vl-form-validation.html
+++ b/demo/vl-form-validation.html
@@ -130,14 +130,14 @@
                         <p is="vl-form-validation-message" error data-vl-error-id="validation-uuid-error"></p>
                     </div>
                     <div is="vl-form-column" data-vl-size="9" data-vl-push="3">
-                        <button id="button-form1" is="vl-button">Formulier valideren</button>
+                        <button is="vl-button">Formulier valideren</button>
                     </div>
                 </div>
             </form>
         </vl-demo>
 
         <vl-demo data-vl-title="Formulier validatie met succes melding">
-            <form id="form-2" data-vl-validate-form-success="true">
+            <form id="form-met-succesmelding" data-vl-validate-form-success="true">
                 <div is="vl-form-grid" data-vl-is-stacked data-vl-v-center>
                     <div is="vl-form-column" data-vl-size="3">
                         <label is="vl-form-label" for="input-1" data-vl-block>Voornaam</label>
@@ -203,7 +203,7 @@
         </vl-demo>
 
         <vl-demo data-vl-title="Formulier zonder validatie">
-            <form id="form-3" novalidate>
+            <form id="form-zonder-validatie" novalidate>
                 <div is="vl-form-grid" data-vl-is-stacked data-vl-v-center>
                     <div is="vl-form-column" data-vl-size="3">
                         <label is="vl-form-message" for="naam">Naam</label>
@@ -227,7 +227,7 @@
                         <label is="vl-form-label" for="input-voornaam" data-vl-block>Voornaam</label>
                     </div>
                     <div is="vl-form-column" data-vl-size="9">
-                        <input id="input-form4-voornaam" is="vl-input-field-demo" placeholder="Jos" data-vl-block data-vl-required="true"
+                        <input id="input-voornaam-err-via-placeholder" is="vl-input-field-demo" placeholder="Jos" data-vl-block data-vl-required="true"
                             data-vl-error-placeholder="validation-voornaam-error" />
                         <p is="vl-form-validation-message" error data-vl-error-id="validation-voornaam-error">De voornaam is verplicht</p>
                     </div>
@@ -236,7 +236,7 @@
                         <label is="vl-form-label" for="input-email" data-vl-block>E-mailadres</label>
                     </div>
                     <div is="vl-form-column" data-vl-size="9">
-                        <input id="input-form4-email" is="vl-input-field-demo" placeholder="email@provider.com" data-vl-block type="email"
+                        <input id="input-email-err-via-placeholder" is="vl-input-field-demo" placeholder="email@provider.com" data-vl-block type="email"
                             data-vl-required="true" 
                             data-vl-error-placeholder="validation-email-error" data-vl-validation-type="email" />
                         <p is="vl-form-validation-message" error data-vl-error-id="validation-email-error">Een geldig 'E-mailadres' is verplicht</p>
@@ -245,7 +245,7 @@
                         <label is="vl-form-label" for="input-iban" data-vl-block>IBAN-nummer</label>
                     </div>
                     <div is="vl-form-column" data-vl-size="9">
-                        <input id="input-form4-iban" is="vl-input-field-demo" placeholder="BE00 0000 0000 0000" data-vl-block type="text"
+                        <input id="input-iban-err-via-placeholder" is="vl-input-field-demo" placeholder="BE00 0000 0000 0000" data-vl-block type="text"
                             data-vl-required="true"
                             data-vl-error-placeholder="validation-iban-error" data-vl-validation-type="iban" />
                         <p is="vl-form-validation-message" error data-vl-error-id="validation-iban-error">Een geldig 'IBAN-nummer' is verplicht</p>
@@ -254,7 +254,7 @@
                         <label is="vl-form-label" for="input-telefoon" data-vl-block>Telefoonnummer</label>
                     </div>
                     <div is="vl-form-column" data-vl-size="9">
-                        <input id="input-form4-telefoon" is="vl-input-field-demo" placeholder="+32 0 000 00 00" data-vl-block type="phone"
+                        <input id="input-telefoon-err-via-placeholder" is="vl-input-field-demo" placeholder="+32 0 000 00 00" data-vl-block type="phone"
                             data-vl-required="true"
                             data-vl-error-placeholder="validation-telefoon-error" data-vl-validation-type="phone" />
                         <p is="vl-form-validation-message" error data-vl-error-id="validation-telefoon-error">Een geldig 'Telefoonnummer' is verplicht</p>
@@ -263,7 +263,7 @@
                         <label is="vl-form-label" for="input-rrn" data-vl-block>Rijksregisternummer</label>
                     </div>
                     <div is="vl-form-column" data-vl-size="9">
-                        <input id="input-form4-rrn" is="vl-input-field-demo" placeholder="11.22.33-444.55" data-vl-block type="text"
+                        <input id="input-rrn-err-via-placeholder" is="vl-input-field-demo" placeholder="11.22.33-444.55" data-vl-block type="text"
                             data-vl-required="true"
                             data-vl-error-placeholder="validation-rrn-error" data-vl-validation-type="rrn" />
                         <p is="vl-form-validation-message" error data-vl-error-id="validation-rrn-error">Een geldig 'Rijksregisternummer' is verplicht</p>
@@ -272,7 +272,7 @@
                         <label is="vl-form-label" for="input-datum" data-vl-block>Geboortedatum</label>
                     </div>
                     <div is="vl-form-column" data-vl-size="9">
-                        <input id="input-form4-datum" is="vl-input-field-demo" placeholder="01.01.2020" data-vl-block type="text"
+                        <input id="input-datum-err-via-placeholder" is="vl-input-field-demo" placeholder="01.01.2020" data-vl-block type="text"
                             data-vl-required="true"
                             data-vl-error-placeholder="validation-datum-error" data-vl-validation-type="date" />
                         <p is="vl-form-validation-message" error data-vl-error-id="validation-datum-error">Een geldige 'Geboortedatum' is verplicht/p>
@@ -281,7 +281,7 @@
                         <label is="vl-form-label" for="select-stad" data-vl-block>Stad</label>
                     </div>
                     <div is="vl-form-column" data-vl-size="9">
-                        <select id="select-form4-stad" is="vl-select-demo" data-vl-block name="validation-select"
+                        <select id="select-stad-err-via-placeholder" is="vl-select-demo" data-vl-block name="validation-select"
                             data-vl-required="true"
                             data-vl-error-placeholder="validation-stad-error" data-vl-validation-type="select">
                             <option placeholder value="">Kies een stad</option>
@@ -294,13 +294,13 @@
                         <label is="vl-form-label" for="input-uuid" data-vl-block>UUID</label>
                     </div>
                     <div is="vl-form-column" data-vl-size="9">
-                        <input id="input-form4-uuid" is="vl-input-field-demo" placeholder="1c6fa548-5eef-11eb-ae93-0242ac130002" data-vl-block type="text"
+                        <input id="input-uuid-err-via-placeholder" is="vl-input-field-demo" placeholder="1c6fa548-5eef-11eb-ae93-0242ac130002" data-vl-block type="text"
                                data-vl-required="true"
                                data-vl-error-placeholder="validation-uuid-error" data-vl-validation-type="uuid" />
                         <p is="vl-form-validation-message" error data-vl-error-id="validation-uuid-error">Een geldige 'UUID' is verplicht</p>
                     </div>
                     <div is="vl-form-column" data-vl-size="9" data-vl-push="3">
-                        <button id="button-form4" is="vl-button">Formulier valideren</button>
+                        <button is="vl-button">Formulier valideren</button>
                     </div>
                 </div>
             </form>

--- a/demo/vl-form-validation.html
+++ b/demo/vl-form-validation.html
@@ -26,7 +26,7 @@
 <body is="vl-body">
     <vl-demo-page data-vl-webcomponent="vl-form-validation" data-vl-link="https://overheid.vlaanderen.be/webuniversum/v3/documentation/forms/vl-ui-form-validation">
         <vl-demo data-vl-title="Formulier validatie">
-            <form id="form-1">
+            <form id="form-met-error-messages-als-attribuut">
                 <div is="vl-form-grid" data-vl-is-stacked data-vl-v-center>
                     <div is="vl-form-column" data-vl-size="3">
                         <label is="vl-form-label" for="input-voornaam" data-vl-block>Voornaam</label>
@@ -221,7 +221,7 @@
         </vl-demo>
 
         <vl-demo data-vl-title="Formulier validatie met foutmelding in error-placeholder-element">
-            <form id="form-4">
+            <form id="form-met-error-messages-via-placeholder">
                 <div is="vl-form-grid" data-vl-is-stacked data-vl-v-center>
                     <div is="vl-form-column" data-vl-size="3">
                         <label is="vl-form-label" for="input-voornaam" data-vl-block>Voornaam</label>

--- a/lib/form-validation.js
+++ b/lib/form-validation.js
@@ -6522,7 +6522,8 @@
         vl.util.removeClass(input, input.getAttribute(fvSuccessClass));
         vl.util.addClass(input, input.getAttribute(fvErrorClassAtt));
         input.setAttribute(fvAriaInvalidAtt, true);
-        errorMessage.style.visibility = 'visible';
+        // errorMessage.style.visibility = 'visible';
+        errorMessage.removeAttribute('hidden');
         if (input.hasAttribute(fvErrorMsgAtt) && error != "ERROR_MESSAGE_IN_PLACEHOLDER" ) {
           errorMessage.innerHTML = error;
         } 
@@ -6603,7 +6604,8 @@
       if (input.hasAttribute(fvErrorMsgAtt)) {
         errorPlaceholder.innerHTML = '';
       } else {
-        errorPlaceholder.style.visibility = 'hidden';
+        // errorPlaceholder.style.visibility = 'hidden';
+        errorPlaceholder.setAttribute('hidden', '');
       }
 
       errorPlaceholder.removeAttribute('aria-describedBy');
@@ -6731,17 +6733,6 @@
         form.addEventListener('reset', function (event) {
           _resetAllError(event.target);
         });
-
-        // todo: variabelen van hoger gebruiken of rechtstreeks inline stylen in html
-        fields = form.querySelectorAll("[data-vl-error-placeholder]");
-        fields.forEach((field) => {
-          const errorPlaceHolder = field.getAttribute('data-vl-error-placeholder');
-          if (errorPlaceHolder) {
-            form.querySelector('[data-vl-error-id="'.concat(errorPlaceHolder).concat('"]')).style.visibility = 'hidden';
-          }
-        })
-
-
       }
     }, {
       key: "reset",

--- a/lib/form-validation.js
+++ b/lib/form-validation.js
@@ -6260,8 +6260,6 @@
       fvAriaDescribedBy = 'aria-describedby',
       fvSelectClass = "js-".concat(vl.ns, "select");
   var fvFirstError = null;
-
-  const errorMessageInPlaceHolder = Symbol('ERROR_MESSAGE_IN_PLACEHOLDER');
   /**
    * Validators
    * data, rrn, uuid, phone, iban, multiselect, numerical
@@ -6459,9 +6457,8 @@
     fieldObj.name = field.getAttribute('name');
     fieldObj.required = field.getAttribute('data-required');
     fieldObj.validationType = field.getAttribute(fvValidationType);
-    fieldObj.errorMessage = field.getAttribute(fvErrorMsgAtt) || errorMessageInPlaceHolder;
+    fieldObj.errorMessage = field.getAttribute(fvErrorMsgAtt);
     fieldObj.validationConstraints = {};
-
     /**
      * if no name is set, set own name
      */

--- a/lib/form-validation.js
+++ b/lib/form-validation.js
@@ -6431,7 +6431,7 @@
     fieldObj.name = field.getAttribute('name');
     fieldObj.required = field.getAttribute('data-required');
     fieldObj.validationType = field.getAttribute(fvValidationType);
-    fieldObj.errorMessage = field.getAttribute(fvErrorMsgAtt);
+    fieldObj.errorMessage = field.getAttribute(fvErrorMsgAtt) || 'ERROR_MESSAGE_IN_PLACEHOLDER';
     fieldObj.validationConstraints = {};
     /**
      * if no name is set, set own name
@@ -6523,7 +6523,7 @@
         vl.util.addClass(input, input.getAttribute(fvErrorClassAtt));
         input.setAttribute(fvAriaInvalidAtt, true);
         errorMessage.style.visibility = 'visible';
-        if (input.hasAttribute(fvErrorMsgAtt) && error != "can't be blank" ) {
+        if (input.hasAttribute(fvErrorMsgAtt) && error != "ERROR_MESSAGE_IN_PLACEHOLDER" ) {
           errorMessage.innerHTML = error;
         } 
         errorMessage.setAttribute(fvAriaDescribedBy, input.getAttribute('id'));
@@ -6602,6 +6602,8 @@
 
       if (input.hasAttribute(fvErrorMsgAtt)) {
         errorPlaceholder.innerHTML = '';
+      } else {
+        errorPlaceholder.style.visibility = 'hidden';
       }
 
       errorPlaceholder.removeAttribute('aria-describedBy');
@@ -6730,7 +6732,7 @@
           _resetAllError(event.target);
         });
 
-        // todo: variabelen van hoger gebruiken
+        // todo: variabelen van hoger gebruiken of rechtstreeks inline stylen in html
         fields = form.querySelectorAll("[data-vl-error-placeholder]");
         fields.forEach((field) => {
           const errorPlaceHolder = field.getAttribute('data-vl-error-placeholder');

--- a/lib/form-validation.js
+++ b/lib/form-validation.js
@@ -6522,6 +6522,7 @@
         vl.util.removeClass(input, input.getAttribute(fvSuccessClass));
         vl.util.addClass(input, input.getAttribute(fvErrorClassAtt));
         input.setAttribute(fvAriaInvalidAtt, true);
+        errorMessage.style.visibility = 'visible';
         errorMessage.innerHTML = error;
         errorMessage.setAttribute(fvAriaDescribedBy, input.getAttribute('id'));
 
@@ -6723,6 +6724,16 @@
         form.addEventListener('reset', function (event) {
           _resetAllError(event.target);
         });
+
+        fields = form.querySelectorAll("[data-vl-error-placeholder]");
+        fields.forEach((field) => {
+          const errorPlaceHolder = field.getAttribute('data-vl-error-placeholder');
+          if (errorPlaceHolder) {
+            form.querySelector('[data-vl-error-id="'.concat(errorPlaceHolder).concat('"]')).style.visibility = 'hidden';
+          }
+        })
+
+
       }
     }, {
       key: "reset",

--- a/lib/form-validation.js
+++ b/lib/form-validation.js
@@ -6255,6 +6255,8 @@
       fvAriaDescribedBy = 'aria-describedby',
       fvSelectClass = "js-".concat(vl.ns, "select");
   var fvFirstError = null;
+
+  const errorMessageInPlaceHolder = Symbol('ERROR_MESSAGE_IN_PLACEHOLDER');
   /**
    * Validators
    * data, rrn, uuid, phone, iban, multiselect
@@ -6431,7 +6433,7 @@
     fieldObj.name = field.getAttribute('name');
     fieldObj.required = field.getAttribute('data-required');
     fieldObj.validationType = field.getAttribute(fvValidationType);
-    fieldObj.errorMessage = field.getAttribute(fvErrorMsgAtt) || 'ERROR_MESSAGE_IN_PLACEHOLDER';
+    fieldObj.errorMessage = field.getAttribute(fvErrorMsgAtt) || errorMessageInPlaceHolder;
     fieldObj.validationConstraints = {};
     /**
      * if no name is set, set own name
@@ -6523,7 +6525,7 @@
         vl.util.addClass(input, input.getAttribute(fvErrorClassAtt));
         input.setAttribute(fvAriaInvalidAtt, true);
         errorMessage.removeAttribute('hidden');
-        if (input.hasAttribute(fvErrorMsgAtt) && error != "ERROR_MESSAGE_IN_PLACEHOLDER" ) {
+        if (input.hasAttribute(fvErrorMsgAtt) && error != errorMessageInPlaceHolder) {
           errorMessage.innerHTML = error;
         } 
         errorMessage.setAttribute(fvAriaDescribedBy, input.getAttribute('id'));

--- a/lib/form-validation.js
+++ b/lib/form-validation.js
@@ -6457,7 +6457,7 @@
     fieldObj.name = field.getAttribute('name');
     fieldObj.required = field.getAttribute('data-required');
     fieldObj.validationType = field.getAttribute(fvValidationType);
-    fieldObj.errorMessage = field.getAttribute(fvErrorMsgAtt);
+    fieldObj.errorMessage = field.getAttribute(fvErrorMsgAtt) || Symbol('error-message-in-placeholder');
     fieldObj.validationConstraints = {};
     /**
      * if no name is set, set own name

--- a/lib/form-validation.js
+++ b/lib/form-validation.js
@@ -6525,7 +6525,7 @@
         vl.util.addClass(input, input.getAttribute(fvErrorClassAtt));
         input.setAttribute(fvAriaInvalidAtt, true);
         errorMessage.removeAttribute('hidden');
-        if (input.hasAttribute(fvErrorMsgAtt) && error != errorMessageInPlaceHolder) {
+        if (input.hasAttribute(fvErrorMsgAtt) && error !== errorMessageInPlaceHolder) {
           errorMessage.innerHTML = error;
         } 
         errorMessage.setAttribute(fvAriaDescribedBy, input.getAttribute('id'));

--- a/lib/form-validation.js
+++ b/lib/form-validation.js
@@ -6557,7 +6557,7 @@
 
   var _showErrors = function _showErrors(form, errors) {
     vl.util.each(form.querySelectorAll("input, textarea, select, [data-vl-error-placeholder]"), function (input) {
-      if ( input.hasAttribute(fvErrorPlchAtt) && input.name.length && form.querySelector("[".concat(fvErrorIDAtt, "=\"").concat(input.getAttribute(fvErrorPlchAtt), "\"]"))) {
+      if (input.hasAttribute(fvErrorPlchAtt) && input.name.length && form.querySelector("[".concat(fvErrorIDAtt, "=\"").concat(input.getAttribute(fvErrorPlchAtt), "\"]"))) {
           _showSuccessForInput(input, errors);
           _showErrorsForInput(input, errors && errors[input.name]);
       }

--- a/lib/form-validation.js
+++ b/lib/form-validation.js
@@ -6523,7 +6523,9 @@
         vl.util.addClass(input, input.getAttribute(fvErrorClassAtt));
         input.setAttribute(fvAriaInvalidAtt, true);
         errorMessage.style.visibility = 'visible';
-        errorMessage.innerHTML = error;
+        if (input.hasAttribute(fvErrorMsgAtt) && error != "can't be blank" ) {
+          errorMessage.innerHTML = error;
+        } 
         errorMessage.setAttribute(fvAriaDescribedBy, input.getAttribute('id'));
 
         if (input.getAttribute(fvValidationType) === 'multi-select' || input.getAttribute(fvValidationType) === 'select') {
@@ -6553,10 +6555,9 @@
 
   var _showErrors = function _showErrors(form, errors) {
     vl.util.each(form.querySelectorAll("input, textarea, select, [data-vl-error-placeholder]"), function (input) {
-      if (input.hasAttribute(fvErrorMsgAtt) && input.hasAttribute(fvErrorPlchAtt) && input.name.length && form.querySelector("[".concat(fvErrorIDAtt, "=\"").concat(input.getAttribute(fvErrorPlchAtt), "\"]"))) {
-        _showSuccessForInput(input, errors);
-
-        _showErrorsForInput(input, errors && errors[input.name]);
+      if ( input.hasAttribute(fvErrorPlchAtt) && input.name.length && form.querySelector("[".concat(fvErrorIDAtt, "=\"").concat(input.getAttribute(fvErrorPlchAtt), "\"]"))) {
+          _showSuccessForInput(input, errors);
+          _showErrorsForInput(input, errors && errors[input.name]);
       }
     });
   };
@@ -6598,7 +6599,11 @@
         vl.util.removeClass(input, input.getAttribute(fvSuccessClass));
       }
 
-      errorPlaceholder.innerHTML = '';
+
+      if (input.hasAttribute(fvErrorMsgAtt)) {
+        errorPlaceholder.innerHTML = '';
+      }
+
       errorPlaceholder.removeAttribute('aria-describedBy');
     }
   };
@@ -6725,6 +6730,7 @@
           _resetAllError(event.target);
         });
 
+        // todo: variabelen van hoger gebruiken
         fields = form.querySelectorAll("[data-vl-error-placeholder]");
         fields.forEach((field) => {
           const errorPlaceHolder = field.getAttribute('data-vl-error-placeholder');

--- a/lib/form-validation.js
+++ b/lib/form-validation.js
@@ -6522,7 +6522,6 @@
         vl.util.removeClass(input, input.getAttribute(fvSuccessClass));
         vl.util.addClass(input, input.getAttribute(fvErrorClassAtt));
         input.setAttribute(fvAriaInvalidAtt, true);
-        // errorMessage.style.visibility = 'visible';
         errorMessage.removeAttribute('hidden');
         if (input.hasAttribute(fvErrorMsgAtt) && error != "ERROR_MESSAGE_IN_PLACEHOLDER" ) {
           errorMessage.innerHTML = error;
@@ -6600,14 +6599,7 @@
         vl.util.removeClass(input, input.getAttribute(fvSuccessClass));
       }
 
-
-      if (input.hasAttribute(fvErrorMsgAtt)) {
-        errorPlaceholder.innerHTML = '';
-      } else {
-        // errorPlaceholder.style.visibility = 'hidden';
-        errorPlaceholder.setAttribute('hidden', '');
-      }
-
+      errorPlaceholder.setAttribute('hidden', '');
       errorPlaceholder.removeAttribute('aria-describedBy');
     }
   };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vl-ui-form-validation",
-  "version": "3.4.3",
+  "version": "3.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -15004,9 +15004,8 @@
       }
     },
     "vl-ui-form-message": {
-      "version": "5.0.7",
-      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/vl-ui-form-message/-/vl-ui-form-message-5.0.7.tgz",
-      "integrity": "sha1-BKHZ1SXUodawCrzVFAXmo6cajXI=",
+      "version": "github:milieuinfo/webcomponent-vl-ui-form-message#1e0cd144a57c80acc887a0790eb77a9d79d1043f",
+      "from": "github:milieuinfo/webcomponent-vl-ui-form-message#formValidationMessageIsHiddenAlsHetErrorIdAttribuutHeeft",
       "dev": true,
       "requires": {
         "vl-ui-core": "^7.1.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,33 +13,49 @@
         "@babel/highlight": "^7.10.4"
       }
     },
+    "@babel/compat-data": {
+      "version": "7.13.8",
+      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/@babel/compat-data/-/compat-data-7.13.8.tgz",
+      "integrity": "sha1-W3g7mAjxXO9xVH8baR80+P9gA6Y=",
+      "dev": true
+    },
     "@babel/core": {
-      "version": "7.12.10",
-      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/@babel/core/-/core-7.12.10.tgz",
-      "integrity": "sha1-t5ouG59w7T2Eu/ttjE74JfYGvM0=",
+      "version": "7.13.8",
+      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/@babel/core/-/core-7.13.8.tgz",
+      "integrity": "sha1-wZHZxYcXiKWR1p6h3APlhDo2gPs=",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.10.4",
-        "@babel/generator": "^7.12.10",
-        "@babel/helper-module-transforms": "^7.12.1",
-        "@babel/helpers": "^7.12.5",
-        "@babel/parser": "^7.12.10",
-        "@babel/template": "^7.12.7",
-        "@babel/traverse": "^7.12.10",
-        "@babel/types": "^7.12.10",
+        "@babel/code-frame": "^7.12.13",
+        "@babel/generator": "^7.13.0",
+        "@babel/helper-compilation-targets": "^7.13.8",
+        "@babel/helper-module-transforms": "^7.13.0",
+        "@babel/helpers": "^7.13.0",
+        "@babel/parser": "^7.13.4",
+        "@babel/template": "^7.12.13",
+        "@babel/traverse": "^7.13.0",
+        "@babel/types": "^7.13.0",
         "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
-        "gensync": "^1.0.0-beta.1",
+        "gensync": "^1.0.0-beta.2",
         "json5": "^2.1.2",
         "lodash": "^4.17.19",
-        "semver": "^5.4.1",
+        "semver": "^6.3.0",
         "source-map": "^0.5.0"
       },
       "dependencies": {
+        "@babel/code-frame": {
+          "version": "7.12.13",
+          "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/@babel/code-frame/-/code-frame-7.12.13.tgz",
+          "integrity": "sha1-3PyCa+72XnXFDiHTg319lXmN1lg=",
+          "dev": true,
+          "requires": {
+            "@babel/highlight": "^7.12.13"
+          }
+        },
         "semver": {
-          "version": "5.7.1",
-          "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha1-qVT5Ma66UI0we78Gnv8MAclhFvc=",
+          "version": "6.3.0",
+          "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha1-7gpkyK9ejO6mdoexM3YeG+y9HT0=",
           "dev": true
         },
         "source-map": {
@@ -51,12 +67,12 @@
       }
     },
     "@babel/generator": {
-      "version": "7.12.11",
-      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/@babel/generator/-/generator-7.12.11.tgz",
-      "integrity": "sha1-mKffe4w1jJo3qweiQFaFMBaro68=",
+      "version": "7.13.9",
+      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/@babel/generator/-/generator-7.13.9.tgz",
+      "integrity": "sha1-Onqpb577jivkLTjYDizrTGTY3jk=",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.12.11",
+        "@babel/types": "^7.13.0",
         "jsesc": "^2.5.1",
         "source-map": "^0.5.0"
       },
@@ -70,154 +86,163 @@
       }
     },
     "@babel/helper-annotate-as-pure": {
-      "version": "7.12.10",
-      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.12.10.tgz",
-      "integrity": "sha1-VKubAA5gqTZEzhez830xOq8dEV0=",
+      "version": "7.12.13",
+      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.12.13.tgz",
+      "integrity": "sha1-D1jobfxLs7H819uAZXDhd9Q5tqs=",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.12.10"
+        "@babel/types": "^7.12.13"
       }
     },
     "@babel/helper-builder-binary-assignment-operator-visitor": {
-      "version": "7.10.4",
-      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.10.4.tgz",
-      "integrity": "sha1-uwt18xv5jL+f8UPBrleLhydK4aM=",
+      "version": "7.12.13",
+      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.12.13.tgz",
+      "integrity": "sha1-a8IDYciLCnTQUTemXKyNPL9vYfw=",
       "dev": true,
       "requires": {
-        "@babel/helper-explode-assignable-expression": "^7.10.4",
-        "@babel/types": "^7.10.4"
+        "@babel/helper-explode-assignable-expression": "^7.12.13",
+        "@babel/types": "^7.12.13"
+      }
+    },
+    "@babel/helper-compilation-targets": {
+      "version": "7.13.8",
+      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/@babel/helper-compilation-targets/-/helper-compilation-targets-7.13.8.tgz",
+      "integrity": "sha1-Ar2yJ4NDmvsRsvAJgUvdiDhL1Gg=",
+      "dev": true,
+      "requires": {
+        "@babel/compat-data": "^7.13.8",
+        "@babel/helper-validator-option": "^7.12.17",
+        "browserslist": "^4.14.5",
+        "semver": "^6.3.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha1-7gpkyK9ejO6mdoexM3YeG+y9HT0=",
+          "dev": true
+        }
       }
     },
     "@babel/helper-create-regexp-features-plugin": {
-      "version": "7.12.7",
-      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.12.7.tgz",
-      "integrity": "sha1-IIQXLpVEP6CgkhS6G7Mo+a6hJ48=",
+      "version": "7.12.17",
+      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.12.17.tgz",
+      "integrity": "sha1-oqyH6eMZJprGVbjUQV6U041mPLc=",
       "dev": true,
       "requires": {
-        "@babel/helper-annotate-as-pure": "^7.10.4",
+        "@babel/helper-annotate-as-pure": "^7.12.13",
         "regexpu-core": "^4.7.1"
       }
     },
-    "@babel/helper-define-map": {
-      "version": "7.10.5",
-      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/@babel/helper-define-map/-/helper-define-map-7.10.5.tgz",
-      "integrity": "sha1-tTwQ23imQIABUmkrEzkxR6y5uzA=",
-      "dev": true,
-      "requires": {
-        "@babel/helper-function-name": "^7.10.4",
-        "@babel/types": "^7.10.5",
-        "lodash": "^4.17.19"
-      }
-    },
     "@babel/helper-explode-assignable-expression": {
-      "version": "7.12.1",
-      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.12.1.tgz",
-      "integrity": "sha1-gAakZmlcSthqKl8vsVtfLDGtVjM=",
+      "version": "7.13.0",
+      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.13.0.tgz",
+      "integrity": "sha1-F7XFn/Rz2flW9A71cM86dsoSZX8=",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.12.1"
+        "@babel/types": "^7.13.0"
       }
     },
     "@babel/helper-function-name": {
-      "version": "7.12.11",
-      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/@babel/helper-function-name/-/helper-function-name-7.12.11.tgz",
-      "integrity": "sha1-H9dziu5dz1PD7P8k8dqcUR7Ee0I=",
+      "version": "7.12.13",
+      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/@babel/helper-function-name/-/helper-function-name-7.12.13.tgz",
+      "integrity": "sha1-k61lbbPDwiMlWf17LD29y+DrN3o=",
       "dev": true,
       "requires": {
-        "@babel/helper-get-function-arity": "^7.12.10",
-        "@babel/template": "^7.12.7",
-        "@babel/types": "^7.12.11"
+        "@babel/helper-get-function-arity": "^7.12.13",
+        "@babel/template": "^7.12.13",
+        "@babel/types": "^7.12.13"
       }
     },
     "@babel/helper-get-function-arity": {
-      "version": "7.12.10",
-      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/@babel/helper-get-function-arity/-/helper-get-function-arity-7.12.10.tgz",
-      "integrity": "sha1-sViBejFltfqiBHgl36YZcN3MFs8=",
+      "version": "7.12.13",
+      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/@babel/helper-get-function-arity/-/helper-get-function-arity-7.12.13.tgz",
+      "integrity": "sha1-vGNFHUA6OzCCuX4diz/lvUCR5YM=",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.12.10"
+        "@babel/types": "^7.12.13"
       }
     },
     "@babel/helper-member-expression-to-functions": {
-      "version": "7.12.7",
-      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.12.7.tgz",
-      "integrity": "sha1-qne9A5bsgRTl4weH76eFmdh0qFU=",
+      "version": "7.13.0",
+      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.13.0.tgz",
+      "integrity": "sha1-aqS7Z44PjCL1jNt5RR0wSURhsJE=",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.12.7"
+        "@babel/types": "^7.13.0"
       }
     },
     "@babel/helper-module-imports": {
-      "version": "7.12.5",
-      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/@babel/helper-module-imports/-/helper-module-imports-7.12.5.tgz",
-      "integrity": "sha1-G/wCKfeUmI927QpNTpCGCFC1Tfs=",
+      "version": "7.12.13",
+      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/@babel/helper-module-imports/-/helper-module-imports-7.12.13.tgz",
+      "integrity": "sha1-7GfkQE9BdQRj5FXMMgP2oy6T/LA=",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.12.5"
+        "@babel/types": "^7.12.13"
       }
     },
     "@babel/helper-module-transforms": {
-      "version": "7.12.1",
-      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/@babel/helper-module-transforms/-/helper-module-transforms-7.12.1.tgz",
-      "integrity": "sha1-eVT+xx9bMsSOSzA7Q3w0RT/XJHw=",
+      "version": "7.13.0",
+      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/@babel/helper-module-transforms/-/helper-module-transforms-7.13.0.tgz",
+      "integrity": "sha1-QutL2O6mi6tGdRISw1e/7YtA9vE=",
       "dev": true,
       "requires": {
-        "@babel/helper-module-imports": "^7.12.1",
-        "@babel/helper-replace-supers": "^7.12.1",
-        "@babel/helper-simple-access": "^7.12.1",
-        "@babel/helper-split-export-declaration": "^7.11.0",
-        "@babel/helper-validator-identifier": "^7.10.4",
-        "@babel/template": "^7.10.4",
-        "@babel/traverse": "^7.12.1",
-        "@babel/types": "^7.12.1",
+        "@babel/helper-module-imports": "^7.12.13",
+        "@babel/helper-replace-supers": "^7.13.0",
+        "@babel/helper-simple-access": "^7.12.13",
+        "@babel/helper-split-export-declaration": "^7.12.13",
+        "@babel/helper-validator-identifier": "^7.12.11",
+        "@babel/template": "^7.12.13",
+        "@babel/traverse": "^7.13.0",
+        "@babel/types": "^7.13.0",
         "lodash": "^4.17.19"
       }
     },
     "@babel/helper-optimise-call-expression": {
-      "version": "7.12.10",
-      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.12.10.tgz",
-      "integrity": "sha1-lMpOMG7hGn3W6fQoI+Ksa0mIHi0=",
+      "version": "7.12.13",
+      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.12.13.tgz",
+      "integrity": "sha1-XALRcbTIYVsecWP4iMHIHDCiquo=",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.12.10"
+        "@babel/types": "^7.12.13"
       }
     },
     "@babel/helper-plugin-utils": {
-      "version": "7.10.4",
-      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.4.tgz",
-      "integrity": "sha1-L3WoMSadT2d95JmG3/WZJ1M883U=",
+      "version": "7.13.0",
+      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/@babel/helper-plugin-utils/-/helper-plugin-utils-7.13.0.tgz",
+      "integrity": "sha1-gGUmzhJa7QM3O8QWqCgyHjpqM68=",
       "dev": true
     },
     "@babel/helper-remap-async-to-generator": {
-      "version": "7.12.1",
-      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.12.1.tgz",
-      "integrity": "sha1-jE27+RYxT2BH3AXmoiFwdCODR/0=",
+      "version": "7.13.0",
+      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.13.0.tgz",
+      "integrity": "sha1-N2p2DZ97SyB3qd0Fqpw5J8rbIgk=",
       "dev": true,
       "requires": {
-        "@babel/helper-annotate-as-pure": "^7.10.4",
-        "@babel/helper-wrap-function": "^7.10.4",
-        "@babel/types": "^7.12.1"
+        "@babel/helper-annotate-as-pure": "^7.12.13",
+        "@babel/helper-wrap-function": "^7.13.0",
+        "@babel/types": "^7.13.0"
       }
     },
     "@babel/helper-replace-supers": {
-      "version": "7.12.11",
-      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/@babel/helper-replace-supers/-/helper-replace-supers-7.12.11.tgz",
-      "integrity": "sha1-6lEWWPxmx5CPkjEG3YjgjRmX1g0=",
+      "version": "7.13.0",
+      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/@babel/helper-replace-supers/-/helper-replace-supers-7.13.0.tgz",
+      "integrity": "sha1-YDS3tRlDCUy0FieEjLIZywK+HSQ=",
       "dev": true,
       "requires": {
-        "@babel/helper-member-expression-to-functions": "^7.12.7",
-        "@babel/helper-optimise-call-expression": "^7.12.10",
-        "@babel/traverse": "^7.12.10",
-        "@babel/types": "^7.12.11"
+        "@babel/helper-member-expression-to-functions": "^7.13.0",
+        "@babel/helper-optimise-call-expression": "^7.12.13",
+        "@babel/traverse": "^7.13.0",
+        "@babel/types": "^7.13.0"
       }
     },
     "@babel/helper-simple-access": {
-      "version": "7.12.1",
-      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/@babel/helper-simple-access/-/helper-simple-access-7.12.1.tgz",
-      "integrity": "sha1-MkJ+WqYVR9OOsebq9f0UJv2tkTY=",
+      "version": "7.12.13",
+      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/@babel/helper-simple-access/-/helper-simple-access-7.12.13.tgz",
+      "integrity": "sha1-hHi8xcrPaqFnKyUcHS3eXM1hpsQ=",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.12.1"
+        "@babel/types": "^7.12.13"
       }
     },
     "@babel/helper-skip-transparent-expression-wrappers": {
@@ -230,12 +255,12 @@
       }
     },
     "@babel/helper-split-export-declaration": {
-      "version": "7.12.11",
-      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.12.11.tgz",
-      "integrity": "sha1-G0zEJEWGQ8R9NwIiI9oz126kYDo=",
+      "version": "7.12.13",
+      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.12.13.tgz",
+      "integrity": "sha1-6UML4AuvPoiw4T5vnU6vITY3KwU=",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.12.11"
+        "@babel/types": "^7.12.13"
       }
     },
     "@babel/helper-validator-identifier": {
@@ -244,36 +269,42 @@
       "integrity": "sha1-yaHwIZF9y1zPDU5FPjmQIpgfye0=",
       "dev": true
     },
+    "@babel/helper-validator-option": {
+      "version": "7.12.17",
+      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/@babel/helper-validator-option/-/helper-validator-option-7.12.17.tgz",
+      "integrity": "sha1-0fvwEuGnm37rv9xtJwuq+NnrmDE=",
+      "dev": true
+    },
     "@babel/helper-wrap-function": {
-      "version": "7.12.3",
-      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/@babel/helper-wrap-function/-/helper-wrap-function-7.12.3.tgz",
-      "integrity": "sha1-MzIzn8TR+78cJ9eVjCfTRwjpkNk=",
+      "version": "7.13.0",
+      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/@babel/helper-wrap-function/-/helper-wrap-function-7.13.0.tgz",
+      "integrity": "sha1-vbXGb9qFJuwjWriUrVOhI1x5/MQ=",
       "dev": true,
       "requires": {
-        "@babel/helper-function-name": "^7.10.4",
-        "@babel/template": "^7.10.4",
-        "@babel/traverse": "^7.10.4",
-        "@babel/types": "^7.10.4"
+        "@babel/helper-function-name": "^7.12.13",
+        "@babel/template": "^7.12.13",
+        "@babel/traverse": "^7.13.0",
+        "@babel/types": "^7.13.0"
       }
     },
     "@babel/helpers": {
-      "version": "7.12.5",
-      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/@babel/helpers/-/helpers-7.12.5.tgz",
-      "integrity": "sha1-Ghukp2jZtYMQ7aUWxEmRP+ZHEW4=",
+      "version": "7.13.0",
+      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/@babel/helpers/-/helpers-7.13.0.tgz",
+      "integrity": "sha1-dkeuVzd7TwQIv0+KevAcQuQbrcA=",
       "dev": true,
       "requires": {
-        "@babel/template": "^7.10.4",
-        "@babel/traverse": "^7.12.5",
-        "@babel/types": "^7.12.5"
+        "@babel/template": "^7.12.13",
+        "@babel/traverse": "^7.13.0",
+        "@babel/types": "^7.13.0"
       }
     },
     "@babel/highlight": {
-      "version": "7.10.4",
-      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/@babel/highlight/-/highlight-7.10.4.tgz",
-      "integrity": "sha1-fRvf1ldTU4+r5sOFls23bZrGAUM=",
+      "version": "7.13.8",
+      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/@babel/highlight/-/highlight-7.13.8.tgz",
+      "integrity": "sha1-ELLax4UmQk38H0dlDQ5BXf2dxIE=",
       "dev": true,
       "requires": {
-        "@babel/helper-validator-identifier": "^7.10.4",
+        "@babel/helper-validator-identifier": "^7.12.11",
         "chalk": "^2.0.0",
         "js-tokens": "^4.0.0"
       },
@@ -292,40 +323,42 @@
       }
     },
     "@babel/parser": {
-      "version": "7.12.11",
-      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/@babel/parser/-/parser-7.12.11.tgz",
-      "integrity": "sha1-nONZW810vFxGaQXobFNbiyUBHnk=",
+      "version": "7.13.9",
+      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/@babel/parser/-/parser-7.13.9.tgz",
+      "integrity": "sha1-yjTLleHC3RJoY6hEZa6O9mEUvpk=",
       "dev": true
     },
     "@babel/plugin-external-helpers": {
-      "version": "7.12.1",
-      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/@babel/plugin-external-helpers/-/plugin-external-helpers-7.12.1.tgz",
-      "integrity": "sha1-30dHdYYLO4vf6u3UVZbNLH82or4=",
+      "version": "7.12.13",
+      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/@babel/plugin-external-helpers/-/plugin-external-helpers-7.12.13.tgz",
+      "integrity": "sha1-Ze+fRXYpclDcYB0qozR2l5DZlm0=",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.10.4"
+        "@babel/helper-plugin-utils": "^7.12.13"
       }
     },
     "@babel/plugin-proposal-async-generator-functions": {
-      "version": "7.12.12",
-      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.12.12.tgz",
-      "integrity": "sha1-BLjyT9RTIAirTnn3iEaP1ahHZWY=",
+      "version": "7.13.8",
+      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.13.8.tgz",
+      "integrity": "sha1-h6rLV0s7xLVgP2/kFFjXKlouxLE=",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.10.4",
-        "@babel/helper-remap-async-to-generator": "^7.12.1",
-        "@babel/plugin-syntax-async-generators": "^7.8.0"
+        "@babel/helper-plugin-utils": "^7.13.0",
+        "@babel/helper-remap-async-to-generator": "^7.13.0",
+        "@babel/plugin-syntax-async-generators": "^7.8.4"
       }
     },
     "@babel/plugin-proposal-object-rest-spread": {
-      "version": "7.12.1",
-      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.12.1.tgz",
-      "integrity": "sha1-3vm9A86g+bcig9rA7CLSicdpEGk=",
+      "version": "7.13.8",
+      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.13.8.tgz",
+      "integrity": "sha1-XSEKTXJ9bOOxj53oLMmaOWTu1go=",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.10.4",
-        "@babel/plugin-syntax-object-rest-spread": "^7.8.0",
-        "@babel/plugin-transform-parameters": "^7.12.1"
+        "@babel/compat-data": "^7.13.8",
+        "@babel/helper-compilation-targets": "^7.13.8",
+        "@babel/helper-plugin-utils": "^7.13.0",
+        "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
+        "@babel/plugin-transform-parameters": "^7.13.0"
       }
     },
     "@babel/plugin-syntax-async-generators": {
@@ -365,56 +398,55 @@
       }
     },
     "@babel/plugin-transform-arrow-functions": {
-      "version": "7.12.1",
-      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.12.1.tgz",
-      "integrity": "sha1-gIP/yGrI53f74ktZZ8SyUh88srM=",
+      "version": "7.13.0",
+      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.13.0.tgz",
+      "integrity": "sha1-EKWb661S1jegJ6+mkujVzv9ePa4=",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.10.4"
+        "@babel/helper-plugin-utils": "^7.13.0"
       }
     },
     "@babel/plugin-transform-async-to-generator": {
-      "version": "7.12.1",
-      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.12.1.tgz",
-      "integrity": "sha1-OEmknMKiLpdDy9a1KSbTAzcimvE=",
+      "version": "7.13.0",
+      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.13.0.tgz",
+      "integrity": "sha1-jhEr9ncbgr8el05eJoBsXJmqUW8=",
       "dev": true,
       "requires": {
-        "@babel/helper-module-imports": "^7.12.1",
-        "@babel/helper-plugin-utils": "^7.10.4",
-        "@babel/helper-remap-async-to-generator": "^7.12.1"
+        "@babel/helper-module-imports": "^7.12.13",
+        "@babel/helper-plugin-utils": "^7.13.0",
+        "@babel/helper-remap-async-to-generator": "^7.13.0"
       }
     },
     "@babel/plugin-transform-block-scoped-functions": {
-      "version": "7.12.1",
-      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.12.1.tgz",
-      "integrity": "sha1-8qGjZb3itxEuCm3tkGf918B5Bdk=",
+      "version": "7.12.13",
+      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.12.13.tgz",
+      "integrity": "sha1-qb8YNvKjm062zwmWdzneKepL9MQ=",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.10.4"
+        "@babel/helper-plugin-utils": "^7.12.13"
       }
     },
     "@babel/plugin-transform-block-scoping": {
-      "version": "7.12.12",
-      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.12.12.tgz",
-      "integrity": "sha1-2TpWehUsIq6jsZKbsRjR0KF1zco=",
+      "version": "7.12.13",
+      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.12.13.tgz",
+      "integrity": "sha1-825VB20G9B39eFV+oDnBtYFkLmE=",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.10.4"
+        "@babel/helper-plugin-utils": "^7.12.13"
       }
     },
     "@babel/plugin-transform-classes": {
-      "version": "7.12.1",
-      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/@babel/plugin-transform-classes/-/plugin-transform-classes-7.12.1.tgz",
-      "integrity": "sha1-ZeZQ/K3dPYjdzmfA+DSj1DajLbY=",
+      "version": "7.13.0",
+      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/@babel/plugin-transform-classes/-/plugin-transform-classes-7.13.0.tgz",
+      "integrity": "sha1-AmUVUHXEKRi/TTpAUxNBdq2bUzs=",
       "dev": true,
       "requires": {
-        "@babel/helper-annotate-as-pure": "^7.10.4",
-        "@babel/helper-define-map": "^7.10.4",
-        "@babel/helper-function-name": "^7.10.4",
-        "@babel/helper-optimise-call-expression": "^7.10.4",
-        "@babel/helper-plugin-utils": "^7.10.4",
-        "@babel/helper-replace-supers": "^7.12.1",
-        "@babel/helper-split-export-declaration": "^7.10.4",
+        "@babel/helper-annotate-as-pure": "^7.12.13",
+        "@babel/helper-function-name": "^7.12.13",
+        "@babel/helper-optimise-call-expression": "^7.12.13",
+        "@babel/helper-plugin-utils": "^7.13.0",
+        "@babel/helper-replace-supers": "^7.13.0",
+        "@babel/helper-split-export-declaration": "^7.12.13",
         "globals": "^11.1.0"
       },
       "dependencies": {
@@ -427,211 +459,239 @@
       }
     },
     "@babel/plugin-transform-computed-properties": {
-      "version": "7.12.1",
-      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.12.1.tgz",
-      "integrity": "sha1-1oz2ybf4OKikFEutvpdUHqCQSFI=",
+      "version": "7.13.0",
+      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.13.0.tgz",
+      "integrity": "sha1-hFxui5u1U3ax+guS7wvcjqBmRO0=",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.10.4"
+        "@babel/helper-plugin-utils": "^7.13.0"
       }
     },
     "@babel/plugin-transform-destructuring": {
-      "version": "7.12.1",
-      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.12.1.tgz",
-      "integrity": "sha1-uaVw/g0KjUYBFkE8tPl+jgiy+Ec=",
+      "version": "7.13.0",
+      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.13.0.tgz",
+      "integrity": "sha1-xdzicAFNTh67HYBhFmlMErcCiWM=",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.10.4"
+        "@babel/helper-plugin-utils": "^7.13.0"
       }
     },
     "@babel/plugin-transform-duplicate-keys": {
-      "version": "7.12.1",
-      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.12.1.tgz",
-      "integrity": "sha1-dFZhuropWsBuaGgieXpp+6osoig=",
+      "version": "7.12.13",
+      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.12.13.tgz",
+      "integrity": "sha1-bwa4eouAP9ko5UuBwljwoAM5BN4=",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.10.4"
+        "@babel/helper-plugin-utils": "^7.12.13"
       }
     },
     "@babel/plugin-transform-exponentiation-operator": {
-      "version": "7.12.1",
-      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.12.1.tgz",
-      "integrity": "sha1-sPLtNWuhvhQo7K8Sj/iiTwKDCuA=",
+      "version": "7.12.13",
+      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.12.13.tgz",
+      "integrity": "sha1-TVI5C5onPmUeSrpq7knvQOgM0KE=",
       "dev": true,
       "requires": {
-        "@babel/helper-builder-binary-assignment-operator-visitor": "^7.10.4",
-        "@babel/helper-plugin-utils": "^7.10.4"
+        "@babel/helper-builder-binary-assignment-operator-visitor": "^7.12.13",
+        "@babel/helper-plugin-utils": "^7.12.13"
       }
     },
     "@babel/plugin-transform-for-of": {
-      "version": "7.12.1",
-      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.12.1.tgz",
-      "integrity": "sha1-B2QPKIZ+0W+VEcmciIKR9WCSHPo=",
+      "version": "7.13.0",
+      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.13.0.tgz",
+      "integrity": "sha1-x5n4gagJGsJrVIZ6hFw+l9JpYGI=",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.10.4"
+        "@babel/helper-plugin-utils": "^7.13.0"
       }
     },
     "@babel/plugin-transform-function-name": {
-      "version": "7.12.1",
-      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.12.1.tgz",
-      "integrity": "sha1-LsdiWMcP4IxtfaFUADpIBiDrpmc=",
+      "version": "7.12.13",
+      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.12.13.tgz",
+      "integrity": "sha1-uwJEUvmq7YYdN0yOeiQlLOOlAFE=",
       "dev": true,
       "requires": {
-        "@babel/helper-function-name": "^7.10.4",
-        "@babel/helper-plugin-utils": "^7.10.4"
+        "@babel/helper-function-name": "^7.12.13",
+        "@babel/helper-plugin-utils": "^7.12.13"
       }
     },
     "@babel/plugin-transform-instanceof": {
-      "version": "7.12.1",
-      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/@babel/plugin-transform-instanceof/-/plugin-transform-instanceof-7.12.1.tgz",
-      "integrity": "sha1-CF3FFgOEor3JTC9RFY+rd7cOpz8=",
+      "version": "7.12.13",
+      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/@babel/plugin-transform-instanceof/-/plugin-transform-instanceof-7.12.13.tgz",
+      "integrity": "sha1-Xfjq2C7UIbcoZiyeDtlDU2yHLO0=",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.10.4"
+        "@babel/helper-plugin-utils": "^7.12.13"
       }
     },
     "@babel/plugin-transform-literals": {
-      "version": "7.12.1",
-      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/@babel/plugin-transform-literals/-/plugin-transform-literals-7.12.1.tgz",
-      "integrity": "sha1-1zuAOiazcBfd+dO7j03Fi/uAb1c=",
+      "version": "7.12.13",
+      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/@babel/plugin-transform-literals/-/plugin-transform-literals-7.12.13.tgz",
+      "integrity": "sha1-LKRbr+SoIBl88xV5Sk0mVg/kvbk=",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.10.4"
+        "@babel/helper-plugin-utils": "^7.12.13"
       }
     },
     "@babel/plugin-transform-modules-amd": {
-      "version": "7.12.1",
-      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.12.1.tgz",
-      "integrity": "sha1-MVQwCwJhhWZu67DA7X+EFf789vk=",
+      "version": "7.13.0",
+      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.13.0.tgz",
+      "integrity": "sha1-GfUR1g49h1PMWm1Od106UYSGbMM=",
       "dev": true,
       "requires": {
-        "@babel/helper-module-transforms": "^7.12.1",
-        "@babel/helper-plugin-utils": "^7.10.4",
+        "@babel/helper-module-transforms": "^7.13.0",
+        "@babel/helper-plugin-utils": "^7.13.0",
         "babel-plugin-dynamic-import-node": "^2.3.3"
       }
     },
     "@babel/plugin-transform-object-super": {
-      "version": "7.12.1",
-      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.12.1.tgz",
-      "integrity": "sha1-TqCGlrjS5lhB0MdwZIKwSL7RBm4=",
+      "version": "7.12.13",
+      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.12.13.tgz",
+      "integrity": "sha1-tEFqLWO4974xTz00m9VanBtRcfc=",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.10.4",
-        "@babel/helper-replace-supers": "^7.12.1"
+        "@babel/helper-plugin-utils": "^7.12.13",
+        "@babel/helper-replace-supers": "^7.12.13"
       }
     },
     "@babel/plugin-transform-parameters": {
-      "version": "7.12.1",
-      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.12.1.tgz",
-      "integrity": "sha1-0uljsDh3FlDJIu/1k3mclthTJV0=",
+      "version": "7.13.0",
+      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.13.0.tgz",
+      "integrity": "sha1-j6dgPjCX+cC3yhpIIbwvtS6eUAc=",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.10.4"
+        "@babel/helper-plugin-utils": "^7.13.0"
       }
     },
     "@babel/plugin-transform-regenerator": {
-      "version": "7.12.1",
-      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.12.1.tgz",
-      "integrity": "sha1-Xwoo2EL2RiKB8GqWToi6jXq0l1M=",
+      "version": "7.12.13",
+      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.12.13.tgz",
+      "integrity": "sha1-tii8ychSYKwa6wW0W94lIQGUovU=",
       "dev": true,
       "requires": {
         "regenerator-transform": "^0.14.2"
       }
     },
     "@babel/plugin-transform-shorthand-properties": {
-      "version": "7.12.1",
-      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.12.1.tgz",
-      "integrity": "sha1-C/nKxVUPzgz98ENCD2YdZF/cdeM=",
+      "version": "7.12.13",
+      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.12.13.tgz",
+      "integrity": "sha1-23VXMrcMU51QTGOQ2c6Q/mSv960=",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.10.4"
+        "@babel/helper-plugin-utils": "^7.12.13"
       }
     },
     "@babel/plugin-transform-spread": {
-      "version": "7.12.1",
-      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/@babel/plugin-transform-spread/-/plugin-transform-spread-7.12.1.tgz",
-      "integrity": "sha1-Un+fMRvk7H/cK3m7ife/iEs+Hh4=",
+      "version": "7.13.0",
+      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/@babel/plugin-transform-spread/-/plugin-transform-spread-7.13.0.tgz",
+      "integrity": "sha1-hIh3EOJzwYFaznrkWfb0Kl0x1f0=",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.10.4",
+        "@babel/helper-plugin-utils": "^7.13.0",
         "@babel/helper-skip-transparent-expression-wrappers": "^7.12.1"
       }
     },
     "@babel/plugin-transform-sticky-regex": {
-      "version": "7.12.7",
-      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.12.7.tgz",
-      "integrity": "sha1-VgIkYTqyOYdFOUjtIdCwsZP6f60=",
+      "version": "7.12.13",
+      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.12.13.tgz",
+      "integrity": "sha1-dg/9k2+s5z+GCuZG+4bugvPQbR8=",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.10.4"
+        "@babel/helper-plugin-utils": "^7.12.13"
       }
     },
     "@babel/plugin-transform-template-literals": {
-      "version": "7.12.1",
-      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.12.1.tgz",
-      "integrity": "sha1-tD7ObtmnnAxxEZ9XbSme8J2UKEM=",
+      "version": "7.13.0",
+      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.13.0.tgz",
+      "integrity": "sha1-o2BJEnl3rZRDje50Q1mNHO/fQJ0=",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.10.4"
+        "@babel/helper-plugin-utils": "^7.13.0"
       }
     },
     "@babel/plugin-transform-typeof-symbol": {
-      "version": "7.12.10",
-      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.12.10.tgz",
-      "integrity": "sha1-3gHEyPllgL0A8YMHKw0Ozc8N7Es=",
+      "version": "7.12.13",
+      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.12.13.tgz",
+      "integrity": "sha1-eF3Weh8upXnZwr5yLejITLhfWn8=",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.10.4"
+        "@babel/helper-plugin-utils": "^7.12.13"
       }
     },
     "@babel/plugin-transform-unicode-regex": {
-      "version": "7.12.1",
-      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.12.1.tgz",
-      "integrity": "sha1-zJZh9hOQ21xl4/66zO/Vxqw/rss=",
+      "version": "7.12.13",
+      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.12.13.tgz",
+      "integrity": "sha1-tSUhaFgE4VWxIC6D/BiNNLtw9aw=",
       "dev": true,
       "requires": {
-        "@babel/helper-create-regexp-features-plugin": "^7.12.1",
-        "@babel/helper-plugin-utils": "^7.10.4"
+        "@babel/helper-create-regexp-features-plugin": "^7.12.13",
+        "@babel/helper-plugin-utils": "^7.12.13"
       }
     },
     "@babel/runtime": {
-      "version": "7.12.5",
-      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/@babel/runtime/-/runtime-7.12.5.tgz",
-      "integrity": "sha1-QQ5+SHRB4bNgwpvnFdhw2bmFiC4=",
+      "version": "7.13.9",
+      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/@babel/runtime/-/runtime-7.13.9.tgz",
+      "integrity": "sha1-l9viEW4mMMSJ8i4GVt7NYKqh/O4=",
       "dev": true,
       "requires": {
         "regenerator-runtime": "^0.13.4"
+      },
+      "dependencies": {
+        "regenerator-runtime": {
+          "version": "0.13.7",
+          "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
+          "integrity": "sha1-ysLazIoepnX+qrrriugziYrkb1U=",
+          "dev": true
+        }
       }
     },
     "@babel/template": {
-      "version": "7.12.7",
-      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/@babel/template/-/template-7.12.7.tgz",
-      "integrity": "sha1-yBcjNpYBjjn7tsSR0vtoTgXtQ7w=",
+      "version": "7.12.13",
+      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/@babel/template/-/template-7.12.13.tgz",
+      "integrity": "sha1-UwJlvooliduzdSOETFvLVZR/syc=",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.10.4",
-        "@babel/parser": "^7.12.7",
-        "@babel/types": "^7.12.7"
+        "@babel/code-frame": "^7.12.13",
+        "@babel/parser": "^7.12.13",
+        "@babel/types": "^7.12.13"
+      },
+      "dependencies": {
+        "@babel/code-frame": {
+          "version": "7.12.13",
+          "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/@babel/code-frame/-/code-frame-7.12.13.tgz",
+          "integrity": "sha1-3PyCa+72XnXFDiHTg319lXmN1lg=",
+          "dev": true,
+          "requires": {
+            "@babel/highlight": "^7.12.13"
+          }
+        }
       }
     },
     "@babel/traverse": {
-      "version": "7.12.12",
-      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/@babel/traverse/-/traverse-7.12.12.tgz",
-      "integrity": "sha1-0M2HiScE7djaAC1nS8gRzmR0M3Y=",
+      "version": "7.13.0",
+      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/@babel/traverse/-/traverse-7.13.0.tgz",
+      "integrity": "sha1-bZV1JHX4bufe0GU23jCaZfyJZsw=",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.12.11",
-        "@babel/generator": "^7.12.11",
-        "@babel/helper-function-name": "^7.12.11",
-        "@babel/helper-split-export-declaration": "^7.12.11",
-        "@babel/parser": "^7.12.11",
-        "@babel/types": "^7.12.12",
+        "@babel/code-frame": "^7.12.13",
+        "@babel/generator": "^7.13.0",
+        "@babel/helper-function-name": "^7.12.13",
+        "@babel/helper-split-export-declaration": "^7.12.13",
+        "@babel/parser": "^7.13.0",
+        "@babel/types": "^7.13.0",
         "debug": "^4.1.0",
         "globals": "^11.1.0",
         "lodash": "^4.17.19"
       },
       "dependencies": {
+        "@babel/code-frame": {
+          "version": "7.12.13",
+          "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/@babel/code-frame/-/code-frame-7.12.13.tgz",
+          "integrity": "sha1-3PyCa+72XnXFDiHTg319lXmN1lg=",
+          "dev": true,
+          "requires": {
+            "@babel/highlight": "^7.12.13"
+          }
+        },
         "globals": {
           "version": "11.12.0",
           "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/globals/-/globals-11.12.0.tgz",
@@ -641,9 +701,9 @@
       }
     },
     "@babel/types": {
-      "version": "7.12.12",
-      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/@babel/types/-/types-7.12.12.tgz",
-      "integrity": "sha1-Rgim7DE6u9h6+lUATTc60EqWwpk=",
+      "version": "7.13.0",
+      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/@babel/types/-/types-7.13.0.tgz",
+      "integrity": "sha1-dEJNKBbwFxtBAPCrNOmjdO/ff4A=",
       "dev": true,
       "requires": {
         "@babel/helper-validator-identifier": "^7.12.11",
@@ -663,9 +723,9 @@
       }
     },
     "@eslint/eslintrc": {
-      "version": "0.3.0",
-      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/@eslint/eslintrc/-/eslintrc-0.3.0.tgz",
-      "integrity": "sha1-1zbWlj1wA7ZRTmMkvsnGAqw0Axg=",
+      "version": "0.4.0",
+      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/@eslint/eslintrc/-/eslintrc-0.4.0.tgz",
+      "integrity": "sha1-mcwKBYTXLx3zi5APsGK6mV85VUc=",
       "dev": true,
       "requires": {
         "ajv": "^6.12.4",
@@ -675,7 +735,6 @@
         "ignore": "^4.0.6",
         "import-fresh": "^3.2.1",
         "js-yaml": "^3.13.1",
-        "lodash": "^4.17.20",
         "minimatch": "^3.0.4",
         "strip-json-comments": "^3.1.1"
       },
@@ -1158,9 +1217,9 @@
       }
     },
     "@types/chai": {
-      "version": "4.2.14",
-      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/@types/chai/-/chai-4.2.14.tgz",
-      "integrity": "sha1-RNLdC13mGFCJN12Xa07FyvaGEZM=",
+      "version": "4.2.15",
+      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/@types/chai/-/chai-4.2.15.tgz",
+      "integrity": "sha1-t6bSY8LOz0S23poFHPSWJJsVRVM=",
       "dev": true
     },
     "@types/chai-subset": {
@@ -1376,9 +1435,9 @@
       }
     },
     "@types/node": {
-      "version": "14.14.22",
-      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/@types/node/-/node-14.14.22.tgz",
-      "integrity": "sha1-DSnzgkcsTM872W/wzkfa9be4Sxg=",
+      "version": "14.14.31",
+      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/@types/node/-/node-14.14.31.tgz",
+      "integrity": "sha1-cihr0z0TeqDRUtR+x8F2JWPTQFU=",
       "dev": true
     },
     "@types/normalize-package-data": {
@@ -1496,9 +1555,9 @@
       "dev": true
     },
     "@types/uglify-js": {
-      "version": "3.11.1",
-      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/@types/uglify-js/-/uglify-js-3.11.1.tgz",
-      "integrity": "sha1-l/8w5hoKpodsJwtfU4c34tarjOs=",
+      "version": "3.12.0",
+      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/@types/uglify-js/-/uglify-js-3.12.0.tgz",
+      "integrity": "sha1-K7BhwmlEFiDUa5RjUMjxbVLvN8U=",
       "dev": true,
       "requires": {
         "source-map": "^0.6.1"
@@ -2019,6 +2078,23 @@
       "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/aws4/-/aws4-1.11.0.tgz",
       "integrity": "sha1-1h9G2DslGSUOJ4Ta9bCUeai0HFk="
     },
+    "axe-core": {
+      "version": "3.5.5",
+      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/axe-core/-/axe-core-3.5.5.tgz",
+      "integrity": "sha1-hDFQc7U/o8DFFnbFiNWdoJoZIic=",
+      "dev": true
+    },
+    "axe-webdriverjs": {
+      "version": "2.3.0",
+      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/axe-webdriverjs/-/axe-webdriverjs-2.3.0.tgz",
+      "integrity": "sha1-klEfvOOGJKV+Gqhh3Yo8c8ajqXI=",
+      "dev": true,
+      "requires": {
+        "axe-core": "^3.3.1",
+        "babel-runtime": "^6.26.0",
+        "depd": "^2.0.0"
+      }
+    },
     "axios": {
       "version": "0.21.1",
       "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/axios/-/axios-0.21.1.tgz",
@@ -2367,20 +2443,6 @@
       "requires": {
         "core-js": "^2.4.0",
         "regenerator-runtime": "^0.11.0"
-      },
-      "dependencies": {
-        "core-js": {
-          "version": "2.6.12",
-          "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/core-js/-/core-js-2.6.12.tgz",
-          "integrity": "sha1-2TM9+nsGXjR8xWgiGdb2kIWcwuw=",
-          "dev": true
-        },
-        "regenerator-runtime": {
-          "version": "0.11.1",
-          "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-          "integrity": "sha1-vgWtf5v30i4Fb5cmzuUBf78Z4uk=",
-          "dev": true
-        }
       }
     },
     "babel-traverse": {
@@ -2568,9 +2630,9 @@
       }
     },
     "bl": {
-      "version": "4.0.3",
-      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/bl/-/bl-4.0.3.tgz",
-      "integrity": "sha1-EtYoetwpCA4ipwXldksqlSLNxIk=",
+      "version": "4.1.0",
+      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha1-RRU1JkGCvsL7vIOmKrmM8R2fezo=",
       "dev": true,
       "requires": {
         "buffer": "^5.5.0",
@@ -2653,6 +2715,12 @@
             "ms": "2.0.0"
           }
         },
+        "depd": {
+          "version": "1.1.2",
+          "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/depd/-/depd-1.1.2.tgz",
+          "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
+          "dev": true
+        },
         "ms": {
           "version": "2.0.0",
           "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/ms/-/ms-2.0.0.tgz",
@@ -2726,6 +2794,12 @@
             "color-convert": "^2.0.1"
           }
         },
+        "camelcase": {
+          "version": "5.3.1",
+          "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/camelcase/-/camelcase-5.3.1.tgz",
+          "integrity": "sha1-48mzFWnhBoEd8kL3FXJaH0xJQyA=",
+          "dev": true
+        },
         "chalk": {
           "version": "3.0.0",
           "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/chalk/-/chalk-3.0.0.tgz",
@@ -2764,9 +2838,9 @@
           "dev": true
         },
         "string-width": {
-          "version": "4.2.0",
-          "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/string-width/-/string-width-4.2.0.tgz",
-          "integrity": "sha1-lSGCxGzHssMT0VluYjmSvRY7crU=",
+          "version": "4.2.2",
+          "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/string-width/-/string-width-4.2.2.tgz",
+          "integrity": "sha1-2v1PlVmnWFz7pSnGoKT3NIjr1MU=",
           "dev": true,
           "requires": {
             "emoji-regex": "^8.0.0",
@@ -2833,6 +2907,19 @@
       "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/browser-stdout/-/browser-stdout-1.3.1.tgz",
       "integrity": "sha1-uqVZ7hTO1zRSIputcyZGfGH6vWA=",
       "dev": true
+    },
+    "browserslist": {
+      "version": "4.16.3",
+      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/browserslist/-/browserslist-4.16.3.tgz",
+      "integrity": "sha1-NAqkaUDX24eHSFZ8XeokpI3fNxc=",
+      "dev": true,
+      "requires": {
+        "caniuse-lite": "^1.0.30001181",
+        "colorette": "^1.2.1",
+        "electron-to-chromium": "^1.3.649",
+        "escalade": "^3.1.1",
+        "node-releases": "^1.1.70"
+      }
     },
     "browserstack": {
       "version": "1.6.1",
@@ -3042,9 +3129,9 @@
       }
     },
     "camelcase": {
-      "version": "5.3.1",
-      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/camelcase/-/camelcase-5.3.1.tgz",
-      "integrity": "sha1-48mzFWnhBoEd8kL3FXJaH0xJQyA=",
+      "version": "6.2.0",
+      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/camelcase/-/camelcase-6.2.0.tgz",
+      "integrity": "sha1-kkr4gcnVJaydh/QNlk5c6pgqGAk=",
       "dev": true
     },
     "camelcase-keys": {
@@ -3056,6 +3143,14 @@
         "camelcase": "^5.3.1",
         "map-obj": "^4.0.0",
         "quick-lru": "^4.0.1"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "5.3.1",
+          "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/camelcase/-/camelcase-5.3.1.tgz",
+          "integrity": "sha1-48mzFWnhBoEd8kL3FXJaH0xJQyA=",
+          "dev": true
+        }
       }
     },
     "cancel-token": {
@@ -3075,6 +3170,12 @@
         }
       }
     },
+    "caniuse-lite": {
+      "version": "1.0.30001196",
+      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/caniuse-lite/-/caniuse-lite-1.0.30001196.tgz",
+      "integrity": "sha1-AFGKIESxq/Pg3zH62+XtkLY/TmQ=",
+      "dev": true
+    },
     "capture-stack-trace": {
       "version": "1.0.1",
       "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/capture-stack-trace/-/capture-stack-trace-1.0.1.tgz",
@@ -3087,16 +3188,16 @@
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
     },
     "chai": {
-      "version": "4.2.0",
-      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/chai/-/chai-4.2.0.tgz",
-      "integrity": "sha1-dgqnLPION5XoSxKHfODoNzeqKeU=",
+      "version": "4.3.3",
+      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/chai/-/chai-4.3.3.tgz",
+      "integrity": "sha1-8rKtlzaZnQen/5XPHnCGxDp29y0=",
       "dev": true,
       "requires": {
         "assertion-error": "^1.1.0",
         "check-error": "^1.0.2",
         "deep-eql": "^3.0.1",
         "get-func-name": "^2.0.0",
-        "pathval": "^1.1.0",
+        "pathval": "^1.1.1",
         "type-detect": "^4.0.5"
       }
     },
@@ -3190,14 +3291,14 @@
       }
     },
     "chokidar": {
-      "version": "3.4.3",
-      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/chokidar/-/chokidar-3.4.3.tgz",
-      "integrity": "sha1-wd84IxRI5FykrFiObHlXO6alfVs=",
+      "version": "3.5.1",
+      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/chokidar/-/chokidar-3.5.1.tgz",
+      "integrity": "sha1-7pznu+vSt59J8wR5nVRo4x4U5oo=",
       "dev": true,
       "requires": {
         "anymatch": "~3.1.1",
         "braces": "~3.0.2",
-        "fsevents": "~2.1.2",
+        "fsevents": "~2.3.1",
         "glob-parent": "~5.1.0",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
@@ -3212,9 +3313,9 @@
       "dev": true
     },
     "chromedriver": {
-      "version": "87.0.7",
-      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/chromedriver/-/chromedriver-87.0.7.tgz",
-      "integrity": "sha1-dAQeAv9/Yz6RuY63B+JHb3E9xMo=",
+      "version": "89.0.0",
+      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/chromedriver/-/chromedriver-89.0.0.tgz",
+      "integrity": "sha1-pvJ6owZABlGiDcBJdv5bLE5l1ho=",
       "dev": true,
       "requires": {
         "@testim/chrome-version": "^1.0.7",
@@ -3371,52 +3472,46 @@
       }
     },
     "cliui": {
-      "version": "5.0.0",
-      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/cliui/-/cliui-5.0.0.tgz",
-      "integrity": "sha1-3u/P2y6AB4SqNPRvoI4GhRx7u8U=",
+      "version": "7.0.4",
+      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha1-oCZe5lVHb8gHrqnfPfjfd4OAi08=",
       "dev": true,
       "requires": {
-        "string-width": "^3.1.0",
-        "strip-ansi": "^5.2.0",
-        "wrap-ansi": "^5.1.0"
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
       },
       "dependencies": {
         "ansi-regex": {
-          "version": "4.1.0",
-          "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha1-i5+PCM8ay4Q3Vqg5yox+MWjFGZc=",
-          "dev": true
-        },
-        "emoji-regex": {
-          "version": "7.0.3",
-          "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/emoji-regex/-/emoji-regex-7.0.3.tgz",
-          "integrity": "sha1-kzoEBShgyF6DwSJHnEdIqOTHIVY=",
+          "version": "5.0.0",
+          "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha1-OIU59VF5vzkznIGvMKZU1p+Hy3U=",
           "dev": true
         },
         "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "version": "3.0.0",
+          "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha1-8Rb4Bk/pCz94RKOJl8C3UFEmnx0=",
           "dev": true
         },
         "string-width": {
-          "version": "3.1.0",
-          "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/string-width/-/string-width-3.1.0.tgz",
-          "integrity": "sha1-InZ74htirxCBV0MG9prFG2IgOWE=",
+          "version": "4.2.2",
+          "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/string-width/-/string-width-4.2.2.tgz",
+          "integrity": "sha1-2v1PlVmnWFz7pSnGoKT3NIjr1MU=",
           "dev": true,
           "requires": {
-            "emoji-regex": "^7.0.1",
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^5.1.0"
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.0"
           }
         },
         "strip-ansi": {
-          "version": "5.2.0",
-          "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/strip-ansi/-/strip-ansi-5.2.0.tgz",
-          "integrity": "sha1-jJpTb+tq/JYr36WxBKUJHBrZwK4=",
+          "version": "6.0.0",
+          "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha1-CxVx3XZpzNTz4G4U7x7tJiJa5TI=",
           "dev": true,
           "requires": {
-            "ansi-regex": "^4.1.0"
+            "ansi-regex": "^5.0.0"
           }
         }
       }
@@ -3499,6 +3594,12 @@
         "color-name": "^1.0.0",
         "simple-swizzle": "^0.2.2"
       }
+    },
+    "colorette": {
+      "version": "1.2.2",
+      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/colorette/-/colorette-1.2.2.tgz",
+      "integrity": "sha1-y8x51emcrqLb8Q6zom/Ys+as+pQ=",
+      "dev": true
     },
     "colors": {
       "version": "1.4.0",
@@ -3736,9 +3837,9 @@
       "dev": true
     },
     "core-js": {
-      "version": "3.8.3",
-      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/core-js/-/core-js-3.8.3.tgz",
-      "integrity": "sha1-whkG4fFPNon5OrzG4miDVQ3ZLdA=",
+      "version": "2.6.12",
+      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/core-js/-/core-js-2.6.12.tgz",
+      "integrity": "sha1-2TM9+nsGXjR8xWgiGdb2kIWcwuw=",
       "dev": true
     },
     "core-util-is": {
@@ -4017,9 +4118,9 @@
       }
     },
     "decamelize": {
-      "version": "1.2.0",
-      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+      "version": "4.0.0",
+      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/decamelize/-/decamelize-4.0.0.tgz",
+      "integrity": "sha1-qkcte/Zg6xXzSU79UxyrfypwmDc=",
       "dev": true
     },
     "decamelize-keys": {
@@ -4032,6 +4133,12 @@
         "map-obj": "^1.0.0"
       },
       "dependencies": {
+        "decamelize": {
+          "version": "1.2.0",
+          "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/decamelize/-/decamelize-1.2.0.tgz",
+          "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+          "dev": true
+        },
         "map-obj": {
           "version": "1.0.1",
           "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/map-obj/-/map-obj-1.0.1.tgz",
@@ -4089,9 +4196,9 @@
       "dev": true
     },
     "defer-to-connect": {
-      "version": "2.0.0",
-      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/defer-to-connect/-/defer-to-connect-2.0.0.tgz",
-      "integrity": "sha1-g9axmdsEFZOshNeBtSIjCMz0wsE=",
+      "version": "2.0.1",
+      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
+      "integrity": "sha1-gBa9tBQ+RjK3ejRJxiNid95SBYc=",
       "dev": true
     },
     "define-properties": {
@@ -4188,9 +4295,9 @@
       "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
     },
     "depd": {
-      "version": "1.1.2",
-      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/depd/-/depd-1.1.2.tgz",
-      "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
+      "version": "2.0.0",
+      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha1-tpYWPMdXVg0JzyLMj60Vcbeedt8=",
       "dev": true
     },
     "destroy": {
@@ -4245,9 +4352,9 @@
       }
     },
     "diff": {
-      "version": "4.0.2",
-      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/diff/-/diff-4.0.2.tgz",
-      "integrity": "sha1-YPOuy4nV+uUgwRqhnvwruYKq3n0=",
+      "version": "5.0.0",
+      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/diff/-/diff-5.0.0.tgz",
+      "integrity": "sha1-ftatdthZ0DB4fsNYVfWx2vMdhSs=",
       "dev": true
     },
     "dir-glob": {
@@ -4449,6 +4556,12 @@
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
       "dev": true
     },
+    "electron-to-chromium": {
+      "version": "1.3.681",
+      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/electron-to-chromium/-/electron-to-chromium-1.3.681.tgz",
+      "integrity": "sha1-+s2RWuRqAg6L5Wai7NwLlERDm+k=",
+      "dev": true
+    },
     "elegant-spinner": {
       "version": "1.0.1",
       "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/elegant-spinner/-/elegant-spinner-1.0.1.tgz",
@@ -4520,9 +4633,9 @@
       }
     },
     "engine.io-client": {
-      "version": "3.5.0",
-      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/engine.io-client/-/engine.io-client-3.5.0.tgz",
-      "integrity": "sha1-/BtNlhYojOTy2vBtz2EkE97JQcc=",
+      "version": "3.5.1",
+      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/engine.io-client/-/engine.io-client-3.5.1.tgz",
+      "integrity": "sha1-tQBFijnAzRl6kh4OdZchp0bQvbk=",
       "dev": true,
       "requires": {
         "component-emitter": "~1.3.0",
@@ -4593,25 +4706,27 @@
       }
     },
     "es-abstract": {
-      "version": "1.18.0-next.2",
-      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/es-abstract/-/es-abstract-1.18.0-next.2.tgz",
-      "integrity": "sha1-CIEBpV8FQfWV5+BXGZ4n3cjzpcI=",
+      "version": "1.18.0",
+      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/es-abstract/-/es-abstract-1.18.0.tgz",
+      "integrity": "sha1-q4CzWe7Lft5MKYAAOQvFrD7HtaQ=",
       "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "es-to-primitive": "^1.2.1",
         "function-bind": "^1.1.1",
-        "get-intrinsic": "^1.0.2",
+        "get-intrinsic": "^1.1.1",
         "has": "^1.0.3",
-        "has-symbols": "^1.0.1",
-        "is-callable": "^1.2.2",
+        "has-symbols": "^1.0.2",
+        "is-callable": "^1.2.3",
         "is-negative-zero": "^2.0.1",
-        "is-regex": "^1.1.1",
+        "is-regex": "^1.1.2",
+        "is-string": "^1.0.5",
         "object-inspect": "^1.9.0",
         "object-keys": "^1.1.1",
         "object.assign": "^4.1.2",
-        "string.prototype.trimend": "^1.0.3",
-        "string.prototype.trimstart": "^1.0.3"
+        "string.prototype.trimend": "^1.0.4",
+        "string.prototype.trimstart": "^1.0.4",
+        "unbox-primitive": "^1.0.0"
       }
     },
     "es-to-primitive": {
@@ -4716,13 +4831,13 @@
       }
     },
     "eslint": {
-      "version": "7.19.0",
-      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/eslint/-/eslint-7.19.0.tgz",
-      "integrity": "sha1-ZxliGxlrX61y5DOHmBMU5dDcP0E=",
+      "version": "7.21.0",
+      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/eslint/-/eslint-7.21.0.tgz",
+      "integrity": "sha1-Ts1bjFtE9d7cm4oRCwG7/rFdHIM=",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.0.0",
-        "@eslint/eslintrc": "^0.3.0",
+        "@babel/code-frame": "7.12.11",
+        "@eslint/eslintrc": "^0.4.0",
         "ajv": "^6.10.0",
         "chalk": "^4.0.0",
         "cross-spawn": "^7.0.2",
@@ -4733,9 +4848,9 @@
         "eslint-utils": "^2.1.0",
         "eslint-visitor-keys": "^2.0.0",
         "espree": "^7.3.1",
-        "esquery": "^1.2.0",
+        "esquery": "^1.4.0",
         "esutils": "^2.0.2",
-        "file-entry-cache": "^6.0.0",
+        "file-entry-cache": "^6.0.1",
         "functional-red-black-tree": "^1.0.1",
         "glob-parent": "^5.0.0",
         "globals": "^12.1.0",
@@ -4872,9 +4987,9 @@
       "dev": true
     },
     "esquery": {
-      "version": "1.3.1",
-      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/esquery/-/esquery-1.3.1.tgz",
-      "integrity": "sha1-t4tYKKqOIU4p+3TE1bdS4cAz2lc=",
+      "version": "1.4.0",
+      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/esquery/-/esquery-1.4.0.tgz",
+      "integrity": "sha1-IUj/w4uC6McFff7UhCWz5h8PJKU=",
       "dev": true,
       "requires": {
         "estraverse": "^5.1.0"
@@ -5159,6 +5274,12 @@
             "ms": "2.0.0"
           }
         },
+        "depd": {
+          "version": "1.1.2",
+          "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/depd/-/depd-1.1.2.tgz",
+          "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
+          "dev": true
+        },
         "ms": {
           "version": "2.0.0",
           "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/ms/-/ms-2.0.0.tgz",
@@ -5364,9 +5485,9 @@
       "dev": true
     },
     "fastq": {
-      "version": "1.10.1",
-      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/fastq/-/fastq-1.10.1.tgz",
-      "integrity": "sha1-i48qyL82MtZ6/NZdrCSNX9xFOF4=",
+      "version": "1.11.0",
+      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/fastq/-/fastq-1.11.0.tgz",
+      "integrity": "sha1-u5+5VaBxMKkY62PB9RYcwypdCFg=",
       "dev": true,
       "requires": {
         "reusify": "^1.0.4"
@@ -5403,6 +5524,14 @@
         "path-to-regexp": "^2.2.1",
         "querystring": "^0.2.0",
         "whatwg-url": "^6.5.0"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "3.9.1",
+          "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/core-js/-/core-js-3.9.1.tgz",
+          "integrity": "sha1-zsjeWT246yqF/7Db3rMSy25UYK4=",
+          "dev": true
+        }
       }
     },
     "figures": {
@@ -5415,9 +5544,9 @@
       }
     },
     "file-entry-cache": {
-      "version": "6.0.0",
-      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/file-entry-cache/-/file-entry-cache-6.0.0.tgz",
-      "integrity": "sha1-eSGonDkcbZPv7CFprGvzAMUn6go=",
+      "version": "6.0.1",
+      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
+      "integrity": "sha1-IRst2WWcsDlLBz5zI6w8kz1SICc=",
       "dev": true,
       "requires": {
         "flat-cache": "^3.0.4"
@@ -5688,9 +5817,9 @@
       "dev": true
     },
     "follow-redirects": {
-      "version": "1.13.2",
-      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/follow-redirects/-/follow-redirects-1.13.2.tgz",
-      "integrity": "sha1-3XPI7/wScoulz0JZ12DqX7g+MUc=",
+      "version": "1.13.3",
+      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/follow-redirects/-/follow-redirects-1.13.3.tgz",
+      "integrity": "sha1-5VmK1QF0wbxOhyMB6CrCzZf5Amc=",
       "dev": true
     },
     "for-in": {
@@ -5799,9 +5928,9 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "fsevents": {
-      "version": "2.1.3",
-      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/fsevents/-/fsevents-2.1.3.tgz",
-      "integrity": "sha1-+3OHA66NL5/pAMM4Nt3r7ouX8j4=",
+      "version": "2.3.2",
+      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha1-ilJveLj99GI7cJ4Ll1xSwkwC/Ro=",
       "dev": true,
       "optional": true
     },
@@ -5921,9 +6050,9 @@
       "dev": true
     },
     "get-intrinsic": {
-      "version": "1.1.0",
-      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/get-intrinsic/-/get-intrinsic-1.1.0.tgz",
-      "integrity": "sha1-iS5ikx5pOMiiPqWq68+2e9l9qX4=",
+      "version": "1.1.1",
+      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
+      "integrity": "sha1-FfWfN2+FXERpY5SPDSTNNje0q8Y=",
       "dev": true,
       "requires": {
         "function-bind": "^1.1.1",
@@ -6405,6 +6534,12 @@
         "ansi-regex": "^2.0.0"
       }
     },
+    "has-bigints": {
+      "version": "1.0.1",
+      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/has-bigints/-/has-bigints-1.0.1.tgz",
+      "integrity": "sha1-ZP5qywIGc+O3jbA1pa9pqp0HsRM=",
+      "dev": true
+    },
     "has-binary2": {
       "version": "1.0.3",
       "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/has-binary2/-/has-binary2-1.0.3.tgz",
@@ -6441,9 +6576,9 @@
       "dev": true
     },
     "has-symbols": {
-      "version": "1.0.1",
-      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/has-symbols/-/has-symbols-1.0.1.tgz",
-      "integrity": "sha1-n1IUdYpEGWxAbZvXbOv4HsLdMeg=",
+      "version": "1.0.2",
+      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/has-symbols/-/has-symbols-1.0.2.tgz",
+      "integrity": "sha1-Fl0wcMADCXUqEjakeTMeOsVvFCM=",
       "dev": true
     },
     "has-unicode": {
@@ -6606,6 +6741,12 @@
         "toidentifier": "1.0.0"
       },
       "dependencies": {
+        "depd": {
+          "version": "1.1.2",
+          "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/depd/-/depd-1.1.2.tgz",
+          "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
+          "dev": true
+        },
         "inherits": {
           "version": "2.0.3",
           "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/inherits/-/inherits-2.0.3.tgz",
@@ -6785,9 +6926,9 @@
       }
     },
     "http2-wrapper": {
-      "version": "1.0.0-beta.5.2",
-      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/http2-wrapper/-/http2-wrapper-1.0.0-beta.5.2.tgz",
-      "integrity": "sha1-i5I965AUSuplz4NLAWo0D8mFVvM=",
+      "version": "1.0.3",
+      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/http2-wrapper/-/http2-wrapper-1.0.3.tgz",
+      "integrity": "sha1-uPVeDB8l1OvQizsMLAeflZCACz0=",
       "dev": true,
       "requires": {
         "quick-lru": "^5.1.1",
@@ -6955,9 +7096,9 @@
           "dev": true
         },
         "string-width": {
-          "version": "4.2.0",
-          "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/string-width/-/string-width-4.2.0.tgz",
-          "integrity": "sha1-lSGCxGzHssMT0VluYjmSvRY7crU=",
+          "version": "4.2.2",
+          "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/string-width/-/string-width-4.2.2.tgz",
+          "integrity": "sha1-2v1PlVmnWFz7pSnGoKT3NIjr1MU=",
           "dev": true,
           "requires": {
             "emoji-regex": "^8.0.0",
@@ -7193,6 +7334,12 @@
       "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
       "dev": true
     },
+    "is-bigint": {
+      "version": "1.0.1",
+      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/is-bigint/-/is-bigint-1.0.1.tgz",
+      "integrity": "sha1-aSMFHfy8dkJ4VAuc4OazITql68I=",
+      "dev": true
+    },
     "is-binary-path": {
       "version": "2.1.0",
       "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/is-binary-path/-/is-binary-path-2.1.0.tgz",
@@ -7200,6 +7347,15 @@
       "dev": true,
       "requires": {
         "binary-extensions": "^2.0.0"
+      }
+    },
+    "is-boolean-object": {
+      "version": "1.1.0",
+      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/is-boolean-object/-/is-boolean-object-1.1.0.tgz",
+      "integrity": "sha1-4qqtOjqPyjTCj27uE1sVbtJYf/A=",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.0"
       }
     },
     "is-buffer": {
@@ -7367,6 +7523,12 @@
       "integrity": "sha1-dTU0W4lnNNX4DE0GxQlVUnoU8Ss=",
       "dev": true
     },
+    "is-number-object": {
+      "version": "1.0.4",
+      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/is-number-object/-/is-number-object-1.0.4.tgz",
+      "integrity": "sha1-NqyV50HPGLKD/B3fXoPaeY4+wZc=",
+      "dev": true
+    },
     "is-obj": {
       "version": "2.0.0",
       "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/is-obj/-/is-obj-2.0.0.tgz",
@@ -7460,11 +7622,12 @@
       "dev": true
     },
     "is-regex": {
-      "version": "1.1.1",
-      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/is-regex/-/is-regex-1.1.1.tgz",
-      "integrity": "sha1-xvmKrMVG9s7FRooHt7FTq1ZKV7k=",
+      "version": "1.1.2",
+      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/is-regex/-/is-regex-1.1.2.tgz",
+      "integrity": "sha1-gcjr3k2xQvLPHFP8htakV4gmYlE=",
       "dev": true,
       "requires": {
+        "call-bind": "^1.0.2",
         "has-symbols": "^1.0.1"
       }
     },
@@ -7495,6 +7658,12 @@
       "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
       "dev": true
     },
+    "is-string": {
+      "version": "1.0.5",
+      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/is-string/-/is-string-1.0.5.tgz",
+      "integrity": "sha1-QEk+0ZjvP/R3uMf5L2ROyCpc06Y=",
+      "dev": true
+    },
     "is-subset": {
       "version": "0.1.1",
       "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/is-subset/-/is-subset-0.1.1.tgz",
@@ -7511,14 +7680,14 @@
       }
     },
     "is-typed-array": {
-      "version": "1.1.4",
-      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/is-typed-array/-/is-typed-array-1.1.4.tgz",
-      "integrity": "sha1-H2bzSig6PJSkM1Q0ZhylP/+AESA=",
+      "version": "1.1.5",
+      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/is-typed-array/-/is-typed-array-1.1.5.tgz",
+      "integrity": "sha1-8y5uCWRV4ynre0I4YkVqohPw604=",
       "dev": true,
       "requires": {
         "available-typed-arrays": "^1.0.2",
-        "call-bind": "^1.0.0",
-        "es-abstract": "^1.18.0-next.1",
+        "call-bind": "^1.0.2",
+        "es-abstract": "^1.18.0-next.2",
         "foreach": "^2.0.5",
         "has-symbols": "^1.0.1"
       }
@@ -7778,9 +7947,9 @@
       }
     },
     "jszip": {
-      "version": "3.5.0",
-      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/jszip/-/jszip-3.5.0.tgz",
-      "integrity": "sha1-tP0fNoJFNGZY54H+yWdYAkieFfY=",
+      "version": "3.6.0",
+      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/jszip/-/jszip-3.6.0.tgz",
+      "integrity": "sha1-g5tygS4/l4GcwTrEE0/87ZXdavk=",
       "dev": true,
       "requires": {
         "lie": "~3.3.0",
@@ -8457,9 +8626,9 @@
       }
     },
     "luxon": {
-      "version": "1.25.0",
-      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/luxon/-/luxon-1.25.0.tgz",
-      "integrity": "sha1-2GIZ6QvAECwOspnWWy9ele/h/nI=",
+      "version": "1.26.0",
+      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/luxon/-/luxon-1.26.0.tgz",
+      "integrity": "sha1-02kjYf2lFHOUglIGHQ+FYd8CtXg=",
       "dev": true
     },
     "magic-string": {
@@ -8586,6 +8755,18 @@
         "yargs-parser": "^18.1.3"
       },
       "dependencies": {
+        "camelcase": {
+          "version": "5.3.1",
+          "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/camelcase/-/camelcase-5.3.1.tgz",
+          "integrity": "sha1-48mzFWnhBoEd8kL3FXJaH0xJQyA=",
+          "dev": true
+        },
+        "decamelize": {
+          "version": "1.2.0",
+          "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/decamelize/-/decamelize-1.2.0.tgz",
+          "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+          "dev": true
+        },
         "type-fest": {
           "version": "0.13.1",
           "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/type-fest/-/type-fest-0.13.1.tgz",
@@ -8783,57 +8964,42 @@
       }
     },
     "mocha": {
-      "version": "8.2.1",
-      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/mocha/-/mocha-8.2.1.tgz",
-      "integrity": "sha1-8vpogX7Q5TND2YnfZczTWLw6Szk=",
+      "version": "8.3.0",
+      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/mocha/-/mocha-8.3.0.tgz",
+      "integrity": "sha1-qDp0MtOCrhyiloYGLX/cLDb2P+U=",
       "dev": true,
       "requires": {
         "@ungap/promise-all-settled": "1.1.2",
         "ansi-colors": "4.1.1",
         "browser-stdout": "1.3.1",
-        "chokidar": "3.4.3",
-        "debug": "4.2.0",
-        "diff": "4.0.2",
+        "chokidar": "3.5.1",
+        "debug": "4.3.1",
+        "diff": "5.0.0",
         "escape-string-regexp": "4.0.0",
         "find-up": "5.0.0",
         "glob": "7.1.6",
         "growl": "1.10.5",
         "he": "1.2.0",
-        "js-yaml": "3.14.0",
+        "js-yaml": "4.0.0",
         "log-symbols": "4.0.0",
         "minimatch": "3.0.4",
-        "ms": "2.1.2",
-        "nanoid": "3.1.12",
+        "ms": "2.1.3",
+        "nanoid": "3.1.20",
         "serialize-javascript": "5.0.1",
         "strip-json-comments": "3.1.1",
-        "supports-color": "7.2.0",
+        "supports-color": "8.1.1",
         "which": "2.0.2",
         "wide-align": "1.1.3",
-        "workerpool": "6.0.2",
-        "yargs": "13.3.2",
-        "yargs-parser": "13.1.2",
+        "workerpool": "6.1.0",
+        "yargs": "16.2.0",
+        "yargs-parser": "20.2.4",
         "yargs-unparser": "2.0.0"
       },
       "dependencies": {
-        "ansi-regex": {
-          "version": "4.1.0",
-          "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha1-i5+PCM8ay4Q3Vqg5yox+MWjFGZc=",
-          "dev": true
-        },
-        "debug": {
-          "version": "4.2.0",
-          "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/debug/-/debug-4.2.0.tgz",
-          "integrity": "sha1-fxUPk5IOlMWPVXTC/QGjEQ7/5/E=",
-          "dev": true,
-          "requires": {
-            "ms": "2.1.2"
-          }
-        },
-        "emoji-regex": {
-          "version": "7.0.3",
-          "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/emoji-regex/-/emoji-regex-7.0.3.tgz",
-          "integrity": "sha1-kzoEBShgyF6DwSJHnEdIqOTHIVY=",
+        "argparse": {
+          "version": "2.0.1",
+          "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/argparse/-/argparse-2.0.1.tgz",
+          "integrity": "sha1-JG9Q88p4oyQPbJl+ipvR6sSeSzg=",
           "dev": true
         },
         "escape-string-regexp": {
@@ -8848,80 +9014,25 @@
           "integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s=",
           "dev": true
         },
-        "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-          "dev": true
-        },
         "js-yaml": {
-          "version": "3.14.0",
-          "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/js-yaml/-/js-yaml-3.14.0.tgz",
-          "integrity": "sha1-p6NBcPJqIbsWJCTYray0ETpp5II=",
+          "version": "4.0.0",
+          "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/js-yaml/-/js-yaml-4.0.0.tgz",
+          "integrity": "sha1-9Ca8D/S0BRkmzViMcRExg0CaEh8=",
           "dev": true,
           "requires": {
-            "argparse": "^1.0.7",
-            "esprima": "^4.0.0"
+            "argparse": "^2.0.1"
           }
         },
-        "locate-path": {
-          "version": "3.0.0",
-          "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/locate-path/-/locate-path-3.0.0.tgz",
-          "integrity": "sha1-2+w7OrdZdYBxtY/ln8QYca8hQA4=",
-          "dev": true,
-          "requires": {
-            "p-locate": "^3.0.0",
-            "path-exists": "^3.0.0"
-          }
-        },
-        "p-limit": {
-          "version": "2.3.0",
-          "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/p-limit/-/p-limit-2.3.0.tgz",
-          "integrity": "sha1-PdM8ZHohT9//2DWTPrCG2g3CHbE=",
-          "dev": true,
-          "requires": {
-            "p-try": "^2.0.0"
-          }
-        },
-        "p-locate": {
-          "version": "3.0.0",
-          "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/p-locate/-/p-locate-3.0.0.tgz",
-          "integrity": "sha1-Mi1poFwCZLJZl9n0DNiokasAZKQ=",
-          "dev": true,
-          "requires": {
-            "p-limit": "^2.0.0"
-          }
-        },
-        "path-exists": {
-          "version": "3.0.0",
-          "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/path-exists/-/path-exists-3.0.0.tgz",
-          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+        "ms": {
+          "version": "2.1.3",
+          "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/ms/-/ms-2.1.3.tgz",
+          "integrity": "sha1-V0yBOM4dK1hh8LRFedut1gxmFbI=",
           "dev": true
-        },
-        "string-width": {
-          "version": "3.1.0",
-          "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/string-width/-/string-width-3.1.0.tgz",
-          "integrity": "sha1-InZ74htirxCBV0MG9prFG2IgOWE=",
-          "dev": true,
-          "requires": {
-            "emoji-regex": "^7.0.1",
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^5.1.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "5.2.0",
-          "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/strip-ansi/-/strip-ansi-5.2.0.tgz",
-          "integrity": "sha1-jJpTb+tq/JYr36WxBKUJHBrZwK4=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^4.1.0"
-          }
         },
         "supports-color": {
-          "version": "7.2.0",
-          "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/supports-color/-/supports-color-7.2.0.tgz",
-          "integrity": "sha1-G33NyzK4E4gBs+R4umpRyqiWSNo=",
+          "version": "8.1.1",
+          "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/supports-color/-/supports-color-8.1.1.tgz",
+          "integrity": "sha1-zW/BfihQDP9WwbhsCn/UpUpzAFw=",
           "dev": true,
           "requires": {
             "has-flag": "^4.0.0"
@@ -8934,35 +9045,6 @@
           "dev": true,
           "requires": {
             "isexe": "^2.0.0"
-          }
-        },
-        "yargs": {
-          "version": "13.3.2",
-          "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/yargs/-/yargs-13.3.2.tgz",
-          "integrity": "sha1-rX/+/sGqWVZayRX4Lcyzipwxot0=",
-          "dev": true,
-          "requires": {
-            "cliui": "^5.0.0",
-            "find-up": "^3.0.0",
-            "get-caller-file": "^2.0.1",
-            "require-directory": "^2.1.1",
-            "require-main-filename": "^2.0.0",
-            "set-blocking": "^2.0.0",
-            "string-width": "^3.0.0",
-            "which-module": "^2.0.0",
-            "y18n": "^4.0.0",
-            "yargs-parser": "^13.1.2"
-          },
-          "dependencies": {
-            "find-up": {
-              "version": "3.0.0",
-              "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/find-up/-/find-up-3.0.0.tgz",
-              "integrity": "sha1-SRafHXmTQwZG2mHsxa41XCHJe3M=",
-              "dev": true,
-              "requires": {
-                "locate-path": "^3.0.0"
-              }
-            }
           }
         }
       }
@@ -9093,9 +9175,9 @@
       "integrity": "sha1-9TdkAGlRaPTMaUrJOT0MlYXu6hk="
     },
     "nanoid": {
-      "version": "3.1.12",
-      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/nanoid/-/nanoid-3.1.12.tgz",
-      "integrity": "sha1-b3c2xi6NOUIWAeSgx3YjqX6mllQ=",
+      "version": "3.1.20",
+      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/nanoid/-/nanoid-3.1.20.tgz",
+      "integrity": "sha1-utwmPGsdzxS3HvqoX2q0wdbPx4g=",
       "dev": true
     },
     "nanomatch": {
@@ -9166,9 +9248,9 @@
       }
     },
     "nise": {
-      "version": "4.0.4",
-      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/nise/-/nise-4.0.4.tgz",
-      "integrity": "sha1-1z3qPlcx5lYZkrj1cL6eNjxFEt0=",
+      "version": "4.1.0",
+      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/nise/-/nise-4.1.0.tgz",
+      "integrity": "sha1-j7daJukLmSAvoeY/RI9Y77ze2vY=",
       "dev": true,
       "requires": {
         "@sinonjs/commons": "^1.7.0",
@@ -9216,6 +9298,12 @@
         "tar": "^2.0.0",
         "which": "1"
       }
+    },
+    "node-releases": {
+      "version": "1.1.71",
+      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/node-releases/-/node-releases-1.1.71.tgz",
+      "integrity": "sha1-yxM0sXmJaxyJ7P3UtyX7e738fbs=",
+      "dev": true
     },
     "node-status-codes": {
       "version": "1.0.0",
@@ -9775,9 +9863,9 @@
       }
     },
     "open": {
-      "version": "7.4.0",
-      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/open/-/open-7.4.0.tgz",
-      "integrity": "sha1-rZW5j4cdmssOyP7MVXCCzJmGYms=",
+      "version": "7.4.2",
+      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/open/-/open-7.4.2.tgz",
+      "integrity": "sha1-uBR+Jtzz5CYxbHMAif1x7dKcIyE=",
       "dev": true,
       "requires": {
         "is-docker": "^2.0.0",
@@ -10636,12 +10724,6 @@
           "integrity": "sha1-bXhlbj2o14tOwLkG98CO8d/j9gg=",
           "dev": true
         },
-        "regenerator-runtime": {
-          "version": "0.11.1",
-          "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-          "integrity": "sha1-vgWtf5v30i4Fb5cmzuUBf78Z4uk=",
-          "dev": true
-        },
         "uglify-js": {
           "version": "3.4.10",
           "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/uglify-js/-/uglify-js-3.4.10.tgz",
@@ -10801,9 +10883,9 @@
           }
         },
         "mime": {
-          "version": "2.5.0",
-          "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/mime/-/mime-2.5.0.tgz",
-          "integrity": "sha1-K0r5NEAXeYBu6YAmu0Lowa4YdrE=",
+          "version": "2.5.2",
+          "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/mime/-/mime-2.5.2.tgz",
+          "integrity": "sha1-bj3GzCuVEGQ4MOXxnVy3U9pe6r4=",
           "dev": true
         },
         "opn": {
@@ -11001,9 +11083,15 @@
       "integrity": "sha1-yzroBuh0BERYTvFUzo7pjUA/PjY="
     },
     "querystring": {
-      "version": "0.2.0",
-      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/querystring/-/querystring-0.2.0.tgz",
-      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
+      "version": "0.2.1",
+      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/querystring/-/querystring-0.2.1.tgz",
+      "integrity": "sha1-QNd2FbsJ0WkCqFw+OKqLXtdhwt0=",
+      "dev": true
+    },
+    "queue-microtask": {
+      "version": "1.2.2",
+      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/queue-microtask/-/queue-microtask-1.2.2.tgz",
+      "integrity": "sha1-q/ZEkebs8POKZQJAPUzaBPNy39M=",
       "dev": true
     },
     "quick-lru": {
@@ -11251,9 +11339,9 @@
       }
     },
     "regenerator-runtime": {
-      "version": "0.13.7",
-      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
-      "integrity": "sha1-ysLazIoepnX+qrrriugziYrkb1U=",
+      "version": "0.11.1",
+      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+      "integrity": "sha1-vgWtf5v30i4Fb5cmzuUBf78Z4uk=",
       "dev": true
     },
     "regenerator-transform": {
@@ -11395,6 +11483,12 @@
           "integrity": "sha1-OIU59VF5vzkznIGvMKZU1p+Hy3U=",
           "dev": true
         },
+        "camelcase": {
+          "version": "5.3.1",
+          "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/camelcase/-/camelcase-5.3.1.tgz",
+          "integrity": "sha1-48mzFWnhBoEd8kL3FXJaH0xJQyA=",
+          "dev": true
+        },
         "chalk": {
           "version": "2.4.2",
           "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/chalk/-/chalk-2.4.2.tgz",
@@ -11430,6 +11524,12 @@
           "version": "1.1.4",
           "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/color-name/-/color-name-1.1.4.tgz",
           "integrity": "sha1-wqCah6y95pVD3m9j+jmVyCbFNqI=",
+          "dev": true
+        },
+        "decamelize": {
+          "version": "1.2.0",
+          "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/decamelize/-/decamelize-1.2.0.tgz",
+          "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
           "dev": true
         },
         "find-up": {
@@ -11476,9 +11576,9 @@
           }
         },
         "string-width": {
-          "version": "4.2.0",
-          "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/string-width/-/string-width-4.2.0.tgz",
-          "integrity": "sha1-lSGCxGzHssMT0VluYjmSvRY7crU=",
+          "version": "4.2.2",
+          "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/string-width/-/string-width-4.2.2.tgz",
+          "integrity": "sha1-2v1PlVmnWFz7pSnGoKT3NIjr1MU=",
           "dev": true,
           "requires": {
             "emoji-regex": "^8.0.0",
@@ -11516,6 +11616,12 @@
               }
             }
           }
+        },
+        "y18n": {
+          "version": "4.0.1",
+          "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/y18n/-/y18n-4.0.1.tgz",
+          "integrity": "sha1-jbK4PDHF11CZu4kLI/MJSJHiR9Q=",
+          "dev": true
         },
         "yargs": {
           "version": "15.4.1",
@@ -11632,12 +11738,12 @@
       "dev": true
     },
     "resolve": {
-      "version": "1.19.0",
-      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/resolve/-/resolve-1.19.0.tgz",
-      "integrity": "sha1-GvW/YwQJc0oGfK4pMYqsf6KaJnw=",
+      "version": "1.20.0",
+      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/resolve/-/resolve-1.20.0.tgz",
+      "integrity": "sha1-YpoBP7P3B1XW8LeTXMHCxTeLGXU=",
       "dev": true,
       "requires": {
-        "is-core-module": "^2.1.0",
+        "is-core-module": "^2.2.0",
         "path-parse": "^1.0.6"
       }
     },
@@ -11734,15 +11840,18 @@
       "dev": true
     },
     "run-parallel": {
-      "version": "1.1.10",
-      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/run-parallel/-/run-parallel-1.1.10.tgz",
-      "integrity": "sha1-YKUbKug2Y2yBN33xbLEHNRvNE+8=",
-      "dev": true
+      "version": "1.2.0",
+      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha1-ZtE2jae9+SHrnZW9GpIp5/IaQ+4=",
+      "dev": true,
+      "requires": {
+        "queue-microtask": "^1.2.2"
+      }
     },
     "rxjs": {
-      "version": "6.6.3",
-      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/rxjs/-/rxjs-6.6.3.tgz",
-      "integrity": "sha1-jKhGNcTaqQDA05Z6buesYCce5VI=",
+      "version": "6.6.6",
+      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/rxjs/-/rxjs-6.6.6.tgz",
+      "integrity": "sha1-FNhBeqWgfF5jOZW1JeHjwN7AO3A=",
       "dev": true,
       "requires": {
         "tslib": "^1.9.0"
@@ -11774,9 +11883,9 @@
       "dev": true
     },
     "sass": {
-      "version": "1.32.5",
-      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/sass/-/sass-1.32.5.tgz",
-      "integrity": "sha1-KILSKtV0jAX6m/9sOw/7xPS54dw=",
+      "version": "1.32.8",
+      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/sass/-/sass-1.32.8.tgz",
+      "integrity": "sha1-8WqavY3FMK3Yg05QaHiigIwDe9w=",
       "dev": true,
       "requires": {
         "chokidar": ">=2.0.0 <4.0.0"
@@ -11899,9 +12008,9 @@
           }
         },
         "got": {
-          "version": "11.8.1",
-          "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/got/-/got-11.8.1.tgz",
-          "integrity": "sha1-3wSt+vLngrq7Paq8eROf7sL36F0=",
+          "version": "11.8.2",
+          "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/got/-/got-11.8.2.tgz",
+          "integrity": "sha1-ers5Weoowx81dvFXbB7/ziPzNZk=",
           "dev": true,
           "requires": {
             "@sindresorhus/is": "^4.0.0",
@@ -11947,24 +12056,35 @@
       }
     },
     "selenium-webdriver": {
-      "version": "4.0.0-alpha.8",
-      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/selenium-webdriver/-/selenium-webdriver-4.0.0-alpha.8.tgz",
-      "integrity": "sha1-XLmfQjmznb3/aseWiT+HPQRN07w=",
+      "version": "4.0.0-beta.1",
+      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/selenium-webdriver/-/selenium-webdriver-4.0.0-beta.1.tgz",
+      "integrity": "sha1-22RbDXdfJuThIjXbBXlqG8Hn79o=",
       "dev": true,
       "requires": {
         "jszip": "^3.5.0",
         "rimraf": "^2.7.1",
-        "tmp": "^0.1.0",
+        "tmp": "^0.2.1",
         "ws": "^7.3.1"
       },
       "dependencies": {
         "tmp": {
-          "version": "0.1.0",
-          "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/tmp/-/tmp-0.1.0.tgz",
-          "integrity": "sha1-7kNKTiJUMILilLpiAdzG6v76KHc=",
+          "version": "0.2.1",
+          "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/tmp/-/tmp-0.2.1.tgz",
+          "integrity": "sha1-hFf8MDfc9HGcJRNnoa9lAO4czxQ=",
           "dev": true,
           "requires": {
-            "rimraf": "^2.6.3"
+            "rimraf": "^3.0.0"
+          },
+          "dependencies": {
+            "rimraf": {
+              "version": "3.0.2",
+              "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/rimraf/-/rimraf-3.0.2.tgz",
+              "integrity": "sha1-8aVAK6YiCtUswSgrrBrjqkn9Bho=",
+              "dev": true,
+              "requires": {
+                "glob": "^7.1.3"
+              }
+            }
           }
         }
       }
@@ -12020,6 +12140,12 @@
           "requires": {
             "ms": "2.0.0"
           }
+        },
+        "depd": {
+          "version": "1.1.2",
+          "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/depd/-/depd-1.1.2.tgz",
+          "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
+          "dev": true
         },
         "http-errors": {
           "version": "1.6.3",
@@ -12102,6 +12228,12 @@
               "dev": true
             }
           }
+        },
+        "depd": {
+          "version": "1.1.2",
+          "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/depd/-/depd-1.1.2.tgz",
+          "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
+          "dev": true
         },
         "ms": {
           "version": "2.1.1",
@@ -12211,14 +12343,25 @@
       "integrity": "sha1-oUEMLt2PB3sItOJTyOrPyvBXRhw="
     },
     "simple-git": {
-      "version": "2.31.0",
-      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/simple-git/-/simple-git-2.31.0.tgz",
-      "integrity": "sha1-PllUweNsdvs4LAjqonSaIG259hM=",
+      "version": "2.36.0",
+      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/simple-git/-/simple-git-2.36.0.tgz",
+      "integrity": "sha1-fB1UjwF4b457atEOISSzdlpvPH8=",
       "dev": true,
       "requires": {
         "@kwsites/file-exists": "^1.1.1",
         "@kwsites/promise-deferred": "^1.1.1",
-        "debug": "^4.3.1"
+        "debug": "^4.3.2"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.2",
+          "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/debug/-/debug-4.3.2.tgz",
+          "integrity": "sha1-8KScGKyHeeMdSgxgKd+3aHPHQos=",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        }
       }
     },
     "simple-swizzle": {
@@ -12252,6 +12395,12 @@
         "supports-color": "^7.1.0"
       },
       "dependencies": {
+        "diff": {
+          "version": "4.0.2",
+          "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/diff/-/diff-4.0.2.tgz",
+          "integrity": "sha1-YPOuy4nV+uUgwRqhnvwruYKq3n0=",
+          "dev": true
+        },
         "has-flag": {
           "version": "4.0.0",
           "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/has-flag/-/has-flag-4.0.0.tgz",
@@ -12599,9 +12748,9 @@
       }
     },
     "source-map-url": {
-      "version": "0.4.0",
-      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/source-map-url/-/source-map-url-0.4.0.tgz",
-      "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
+      "version": "0.4.1",
+      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/source-map-url/-/source-map-url-0.4.1.tgz",
+      "integrity": "sha1-CvZmBadFpaL5HPG7+KevvCg97FY=",
       "dev": true
     },
     "spdx-correct": {
@@ -12877,22 +13026,22 @@
       "integrity": "sha1-AErUTIr8cnUnsQjNRitNlxzUabw="
     },
     "string.prototype.trimend": {
-      "version": "1.0.3",
-      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/string.prototype.trimend/-/string.prototype.trimend-1.0.3.tgz",
-      "integrity": "sha1-oivVPMpcfPRNfJ1ccyEYhz1s0Ys=",
+      "version": "1.0.4",
+      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
+      "integrity": "sha1-51rpDClCxjUEaGwYsoe0oLGkX4A=",
       "dev": true,
       "requires": {
-        "call-bind": "^1.0.0",
+        "call-bind": "^1.0.2",
         "define-properties": "^1.1.3"
       }
     },
     "string.prototype.trimstart": {
-      "version": "1.0.3",
-      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/string.prototype.trimstart/-/string.prototype.trimstart-1.0.3.tgz",
-      "integrity": "sha1-m0y1kOEjuzZWRAHVmCQpjeUP1ao=",
+      "version": "1.0.4",
+      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
+      "integrity": "sha1-s2OZr0qymZtMnGSL16P7K7Jv7u0=",
       "dev": true,
       "requires": {
-        "call-bind": "^1.0.0",
+        "call-bind": "^1.0.2",
         "define-properties": "^1.1.3"
       }
     },
@@ -13180,6 +13329,12 @@
           "version": "1.0.0",
           "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
           "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4=",
+          "dev": true
+        },
+        "decamelize": {
+          "version": "1.2.0",
+          "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/decamelize/-/decamelize-1.2.0.tgz",
+          "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
           "dev": true
         },
         "dot-prop": {
@@ -13653,9 +13808,9 @@
       },
       "dependencies": {
         "ajv": {
-          "version": "7.0.3",
-          "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/ajv/-/ajv-7.0.3.tgz",
-          "integrity": "sha1-E650fv8SXK+yMKxQSyQGzzce7OI=",
+          "version": "7.1.1",
+          "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/ajv/-/ajv-7.1.1.tgz",
+          "integrity": "sha1-Hms3pFQCH6mUFxPzi5UvwcjTKoQ=",
           "dev": true,
           "requires": {
             "fast-deep-equal": "^3.1.1",
@@ -13683,9 +13838,9 @@
           "dev": true
         },
         "string-width": {
-          "version": "4.2.0",
-          "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/string-width/-/string-width-4.2.0.tgz",
-          "integrity": "sha1-lSGCxGzHssMT0VluYjmSvRY7crU=",
+          "version": "4.2.2",
+          "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/string-width/-/string-width-4.2.2.tgz",
+          "integrity": "sha1-2v1PlVmnWFz7pSnGoKT3NIjr1MU=",
           "dev": true,
           "requires": {
             "emoji-regex": "^8.0.0",
@@ -13877,9 +14032,9 @@
       }
     },
     "terser": {
-      "version": "5.5.1",
-      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/terser/-/terser-5.5.1.tgz",
-      "integrity": "sha1-VAyqJROdb0lv3qBW5BQoSIb7Iok=",
+      "version": "5.6.0",
+      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/terser/-/terser-5.6.0.tgz",
+      "integrity": "sha1-E4zfIcXjEAsbPd/d9yCWL4i63NI=",
       "dev": true,
       "requires": {
         "commander": "^2.20.0",
@@ -14226,15 +14381,27 @@
       "dev": true
     },
     "ua-parser-js": {
-      "version": "0.7.23",
-      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/ua-parser-js/-/ua-parser-js-0.7.23.tgz",
-      "integrity": "sha1-cE1n+VHhMZX7zT14gYV39bwdVHs=",
+      "version": "0.7.24",
+      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/ua-parser-js/-/ua-parser-js-0.7.24.tgz",
+      "integrity": "sha1-jT7OpG7U8fHWPsJfF9hWgQXcAnw=",
       "dev": true
     },
     "uglify-js": {
       "version": "3.12.3",
       "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/uglify-js/-/uglify-js-3.12.3.tgz",
       "integrity": "sha1-uybEq+DmjFXpd2vKm+2ZpN9z+s8="
+    },
+    "unbox-primitive": {
+      "version": "1.0.0",
+      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/unbox-primitive/-/unbox-primitive-1.0.0.tgz",
+      "integrity": "sha1-7qy8Sv+ijps9NrXq7MxQsyUbHT8=",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.1",
+        "has-bigints": "^1.0.0",
+        "has-symbols": "^1.0.0",
+        "which-boxed-primitive": "^1.0.1"
+      }
     },
     "underscore": {
       "version": "1.12.0",
@@ -14481,9 +14648,9 @@
       }
     },
     "urijs": {
-      "version": "1.19.5",
-      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/urijs/-/urijs-1.19.5.tgz",
-      "integrity": "sha1-EZaDq0svsL1jfl6m3ZEXvKxo0+Q=",
+      "version": "1.19.6",
+      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/urijs/-/urijs-1.19.6.tgz",
+      "integrity": "sha1-UfjLF8oW+u+yC5oxrGD4SqK3yHA=",
       "dev": true
     },
     "urix": {
@@ -14682,27 +14849,49 @@
       }
     },
     "vl-ui-action-group": {
-      "version": "3.1.2",
-      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/vl-ui-action-group/-/vl-ui-action-group-3.1.2.tgz",
-      "integrity": "sha1-eRxmNY1+or399yzOMVM8uKUW1to=",
+      "version": "3.1.3",
+      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/vl-ui-action-group/-/vl-ui-action-group-3.1.3.tgz",
+      "integrity": "sha1-lH7w9JcvFFRgSxq07z+ofijS5iQ=",
       "dev": true,
       "requires": {
-        "vl-ui-core": "^7.0.1"
+        "vl-ui-core": "^7.1.1"
       }
     },
     "vl-ui-body": {
-      "version": "1.0.7",
-      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/vl-ui-body/-/vl-ui-body-1.0.7.tgz",
-      "integrity": "sha1-GpwYM/cL+KrXSI2FGRyVItBoz3Q=",
+      "version": "1.0.8",
+      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/vl-ui-body/-/vl-ui-body-1.0.8.tgz",
+      "integrity": "sha1-ovwMNs7myc5hoBeUsyCfArgDJ8U=",
       "dev": true,
       "requires": {
-        "vl-ui-core": "^7.0.1"
+        "vl-ui-core": "^7.1.1"
+      }
+    },
+    "vl-ui-button": {
+      "version": "5.0.10",
+      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/vl-ui-button/-/vl-ui-button-5.0.10.tgz",
+      "integrity": "sha1-AkBM+T7JJoRyhxj8auHoCztPJhM=",
+      "dev": true,
+      "requires": {
+        "vl-ui-core": "^7.1.1",
+        "vl-ui-link": "^4.0.8"
+      }
+    },
+    "vl-ui-code-preview": {
+      "version": "1.0.5",
+      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/vl-ui-code-preview/-/vl-ui-code-preview-1.0.5.tgz",
+      "integrity": "sha1-MCNXyUNx7VvcSQg9Wmhgqaw09QQ=",
+      "dev": true,
+      "requires": {
+        "@govflanders/vl-ui-code-preview": "^3.12.3",
+        "@govflanders/vl-ui-core": "^4.1.3",
+        "@govflanders/vl-ui-util": "^3.12.3",
+        "vl-ui-core": "^7.2.0"
       },
       "dependencies": {
         "vl-ui-core": {
-          "version": "7.0.2",
-          "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/vl-ui-core/-/vl-ui-core-7.0.2.tgz",
-          "integrity": "sha1-Z45aH9o5Lm6iAy3Vqx0eTwnyxns=",
+          "version": "7.2.0",
+          "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/vl-ui-core/-/vl-ui-core-7.2.0.tgz",
+          "integrity": "sha1-5h3hnBJtjAWiMdZH+8hnfeeFJvI=",
           "dev": true,
           "requires": {
             "@govflanders/vl-ui-core": "^4.1.3",
@@ -14712,32 +14901,10 @@
         }
       }
     },
-    "vl-ui-button": {
-      "version": "5.0.9",
-      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/vl-ui-button/-/vl-ui-button-5.0.9.tgz",
-      "integrity": "sha1-obLVk4px/NnwmE8YUUAV22i0vMY=",
-      "dev": true,
-      "requires": {
-        "vl-ui-core": "^7.1.0",
-        "vl-ui-link": "^4.0.7"
-      }
-    },
-    "vl-ui-code-preview": {
-      "version": "1.0.3",
-      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/vl-ui-code-preview/-/vl-ui-code-preview-1.0.3.tgz",
-      "integrity": "sha1-QBUWd8euDwVxyGUGj/Bk4Vc8TyQ=",
-      "dev": true,
-      "requires": {
-        "@govflanders/vl-ui-code-preview": "^3.12.3",
-        "@govflanders/vl-ui-core": "^4.1.3",
-        "@govflanders/vl-ui-util": "^3.12.3",
-        "vl-ui-core": "^7.0.1"
-      }
-    },
     "vl-ui-core": {
-      "version": "7.1.1",
-      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/vl-ui-core/-/vl-ui-core-7.1.1.tgz",
-      "integrity": "sha1-sOyLa0JtSNV6m1rTtL+g0L+WVfw=",
+      "version": "7.2.0",
+      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/vl-ui-core/-/vl-ui-core-7.2.0.tgz",
+      "integrity": "sha1-5h3hnBJtjAWiMdZH+8hnfeeFJvI=",
       "requires": {
         "@govflanders/vl-ui-core": "^4.1.3",
         "@govflanders/vl-ui-util": "^3.12.3",
@@ -14745,242 +14912,276 @@
       }
     },
     "vl-ui-datepicker": {
-      "version": "3.2.4",
-      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/vl-ui-datepicker/-/vl-ui-datepicker-3.2.4.tgz",
-      "integrity": "sha1-gGyVE4kxzHKGzg7u1lnVVx1PEhg=",
+      "version": "3.2.5",
+      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/vl-ui-datepicker/-/vl-ui-datepicker-3.2.5.tgz",
+      "integrity": "sha1-jTQ59MHpCdboPZ4bqWiN9+BDkmA=",
       "dev": true,
       "requires": {
-        "vl-ui-core": "^7.0.3",
-        "vl-ui-form-validation": "^3.4.0",
-        "vl-ui-icon": "^5.2.1",
-        "vl-ui-input-addon": "^3.1.7",
-        "vl-ui-input-field": "^3.2.7",
-        "vl-ui-input-group": "^4.0.6"
+        "vl-ui-core": "^7.1.1",
+        "vl-ui-form-validation": "^3.4.3",
+        "vl-ui-icon": "^5.2.2",
+        "vl-ui-input-addon": "^3.1.8",
+        "vl-ui-input-field": "^3.2.8",
+        "vl-ui-input-group": "^4.0.7"
       }
     },
     "vl-ui-demo": {
-      "version": "1.3.0",
-      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/vl-ui-demo/-/vl-ui-demo-1.3.0.tgz",
-      "integrity": "sha1-ksy2I12i47ssrZJ9LxqQ2p+5yKU=",
+      "version": "1.3.3",
+      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/vl-ui-demo/-/vl-ui-demo-1.3.3.tgz",
+      "integrity": "sha1-Jkj1ZKY+tz9ahFLN2qykICSkvWc=",
       "dev": true,
       "requires": {
-        "vl-ui-action-group": "^3.1.1",
-        "vl-ui-button": "^5.0.7",
-        "vl-ui-code-preview": "^1.0.2",
-        "vl-ui-core": "^7.0.0",
-        "vl-ui-footer": "^3.3.1",
-        "vl-ui-functional-header": "^1.2.8",
-        "vl-ui-grid": "^3.1.5",
-        "vl-ui-header": "^3.3.1",
-        "vl-ui-template": "^3.1.1",
-        "vl-ui-titles": "^3.0.7"
+        "vl-ui-action-group": "^3.1.3",
+        "vl-ui-button": "^5.0.10",
+        "vl-ui-code-preview": "^1.0.5",
+        "vl-ui-core": "^7.2.0",
+        "vl-ui-footer": "^3.3.3",
+        "vl-ui-functional-header": "^1.2.11",
+        "vl-ui-grid": "^3.3.0",
+        "vl-ui-header": "^3.3.3",
+        "vl-ui-template": "^3.1.2",
+        "vl-ui-titles": "^3.1.1"
+      },
+      "dependencies": {
+        "vl-ui-button": {
+          "version": "5.0.10",
+          "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/vl-ui-button/-/vl-ui-button-5.0.10.tgz",
+          "integrity": "sha1-AkBM+T7JJoRyhxj8auHoCztPJhM=",
+          "dev": true,
+          "requires": {
+            "vl-ui-core": "^7.1.1",
+            "vl-ui-link": "^4.0.8"
+          }
+        },
+        "vl-ui-core": {
+          "version": "7.2.0",
+          "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/vl-ui-core/-/vl-ui-core-7.2.0.tgz",
+          "integrity": "sha1-5h3hnBJtjAWiMdZH+8hnfeeFJvI=",
+          "dev": true,
+          "requires": {
+            "@govflanders/vl-ui-core": "^4.1.3",
+            "@govflanders/vl-ui-util": "^3.12.3",
+            "@ungap/custom-elements": "^0.1.10"
+          }
+        },
+        "vl-ui-grid": {
+          "version": "3.3.0",
+          "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/vl-ui-grid/-/vl-ui-grid-3.3.0.tgz",
+          "integrity": "sha1-FWep9UWBu1SeFKIZiSDvxbRTx6w=",
+          "dev": true,
+          "requires": {
+            "vl-ui-core": "^7.1.1"
+          }
+        },
+        "vl-ui-link": {
+          "version": "4.0.8",
+          "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/vl-ui-link/-/vl-ui-link-4.0.8.tgz",
+          "integrity": "sha1-OYT86YHHxxKZZYJX0Yt5jntwKk4=",
+          "dev": true,
+          "requires": {
+            "vl-ui-core": "^7.1.1"
+          }
+        }
       }
     },
     "vl-ui-footer": {
-      "version": "3.3.2",
-      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/vl-ui-footer/-/vl-ui-footer-3.3.2.tgz",
-      "integrity": "sha1-Aiqp3VbC5XwDubmBuWZhxItJmXU=",
+      "version": "3.3.3",
+      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/vl-ui-footer/-/vl-ui-footer-3.3.3.tgz",
+      "integrity": "sha1-KykFRFXEpEDkHnSZ69nqFVvUwLQ=",
       "dev": true,
       "requires": {
-        "vl-ui-core": "^7.0.1"
+        "vl-ui-core": "^7.1.1"
       }
     },
     "vl-ui-form-grid": {
-      "version": "3.0.8",
-      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/vl-ui-form-grid/-/vl-ui-form-grid-3.0.8.tgz",
-      "integrity": "sha1-sdd+hXmCtN6IY2ti7n2W+0aYht8=",
+      "version": "3.0.9",
+      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/vl-ui-form-grid/-/vl-ui-form-grid-3.0.9.tgz",
+      "integrity": "sha1-Vx1y77EGWboTaDkk5grvt11KKtU=",
       "dev": true,
       "requires": {
-        "vl-ui-core": "^7.0.1",
-        "vl-ui-grid": "^3.1.6"
-      },
-      "dependencies": {
-        "vl-ui-core": {
-          "version": "7.0.2",
-          "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/vl-ui-core/-/vl-ui-core-7.0.2.tgz",
-          "integrity": "sha1-Z45aH9o5Lm6iAy3Vqx0eTwnyxns=",
-          "dev": true,
-          "requires": {
-            "@govflanders/vl-ui-core": "^4.1.3",
-            "@govflanders/vl-ui-util": "^3.12.3",
-            "@ungap/custom-elements": "^0.1.10"
-          }
-        }
+        "vl-ui-core": "^7.1.1",
+        "vl-ui-grid": "^3.2.1"
       }
     },
     "vl-ui-form-message": {
-      "version": "5.0.6",
-      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/vl-ui-form-message/-/vl-ui-form-message-5.0.6.tgz",
-      "integrity": "sha1-Ch7cWZeyAXZSNNUTBUK6kimpdBY=",
+      "version": "5.0.7",
+      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/vl-ui-form-message/-/vl-ui-form-message-5.0.7.tgz",
+      "integrity": "sha1-BKHZ1SXUodawCrzVFAXmo6cajXI=",
       "dev": true,
       "requires": {
-        "vl-ui-core": "^7.0.1"
-      },
-      "dependencies": {
-        "vl-ui-core": {
-          "version": "7.0.2",
-          "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/vl-ui-core/-/vl-ui-core-7.0.2.tgz",
-          "integrity": "sha1-Z45aH9o5Lm6iAy3Vqx0eTwnyxns=",
-          "dev": true,
-          "requires": {
-            "@govflanders/vl-ui-core": "^4.1.3",
-            "@govflanders/vl-ui-util": "^3.12.3",
-            "@ungap/custom-elements": "^0.1.10"
-          }
-        }
+        "vl-ui-core": "^7.1.1"
       }
     },
     "vl-ui-form-validation": {
-      "version": "3.4.0",
-      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/vl-ui-form-validation/-/vl-ui-form-validation-3.4.0.tgz",
-      "integrity": "sha1-mHMgUlIaBDBRT7Gte0gviOQvMIM=",
+      "version": "3.4.3",
+      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/vl-ui-form-validation/-/vl-ui-form-validation-3.4.3.tgz",
+      "integrity": "sha1-MacTeC1ZnEZoLawrv3yqktg/bso=",
       "dev": true,
       "requires": {
         "@govflanders/vl-ui-form-validation": "^4.0.6",
-        "vl-ui-core": "^7.0.2"
+        "vl-ui-core": "^7.1.1"
       }
     },
     "vl-ui-functional-header": {
-      "version": "1.2.9",
-      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/vl-ui-functional-header/-/vl-ui-functional-header-1.2.9.tgz",
-      "integrity": "sha1-4kzZwmPU3O78hB1Xg4kQN49N69Y=",
+      "version": "1.2.11",
+      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/vl-ui-functional-header/-/vl-ui-functional-header-1.2.11.tgz",
+      "integrity": "sha1-EGxr4irU642SCkTQoYoipbWAgiU=",
       "dev": true,
       "requires": {
-        "vl-ui-core": "^7.0.1",
-        "vl-ui-icon": "^5.2.1",
-        "vl-ui-link": "^4.0.7"
-      }
-    },
-    "vl-ui-grid": {
-      "version": "3.2.0",
-      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/vl-ui-grid/-/vl-ui-grid-3.2.0.tgz",
-      "integrity": "sha1-8xeviUTXkyh6hCVwrk6advNEEPU=",
-      "dev": true,
-      "requires": {
-        "vl-ui-core": "^7.0.1"
+        "vl-ui-core": "^7.2.0",
+        "vl-ui-icon": "^5.2.2",
+        "vl-ui-link": "^4.0.8"
       },
       "dependencies": {
         "vl-ui-core": {
-          "version": "7.0.2",
-          "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/vl-ui-core/-/vl-ui-core-7.0.2.tgz",
-          "integrity": "sha1-Z45aH9o5Lm6iAy3Vqx0eTwnyxns=",
+          "version": "7.2.0",
+          "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/vl-ui-core/-/vl-ui-core-7.2.0.tgz",
+          "integrity": "sha1-5h3hnBJtjAWiMdZH+8hnfeeFJvI=",
           "dev": true,
           "requires": {
             "@govflanders/vl-ui-core": "^4.1.3",
             "@govflanders/vl-ui-util": "^3.12.3",
             "@ungap/custom-elements": "^0.1.10"
           }
+        },
+        "vl-ui-icon": {
+          "version": "5.2.2",
+          "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/vl-ui-icon/-/vl-ui-icon-5.2.2.tgz",
+          "integrity": "sha1-8f+pkkXgbdYRMlkYTz3iCexw3lc=",
+          "dev": true,
+          "requires": {
+            "vl-ui-core": "^7.1.1"
+          }
+        },
+        "vl-ui-link": {
+          "version": "4.0.8",
+          "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/vl-ui-link/-/vl-ui-link-4.0.8.tgz",
+          "integrity": "sha1-OYT86YHHxxKZZYJX0Yt5jntwKk4=",
+          "dev": true,
+          "requires": {
+            "vl-ui-core": "^7.1.1"
+          }
         }
       }
     },
-    "vl-ui-header": {
-      "version": "3.3.2",
-      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/vl-ui-header/-/vl-ui-header-3.3.2.tgz",
-      "integrity": "sha1-f3aD/3DNSDetaZW34CXbSbHhzwI=",
+    "vl-ui-grid": {
+      "version": "3.3.0",
+      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/vl-ui-grid/-/vl-ui-grid-3.3.0.tgz",
+      "integrity": "sha1-FWep9UWBu1SeFKIZiSDvxbRTx6w=",
       "dev": true,
       "requires": {
-        "vl-ui-core": "^7.0.1"
+        "vl-ui-core": "^7.1.1"
+      }
+    },
+    "vl-ui-header": {
+      "version": "3.3.3",
+      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/vl-ui-header/-/vl-ui-header-3.3.3.tgz",
+      "integrity": "sha1-dFADaHb0T2dvL/joI5EkVPMVQUE=",
+      "dev": true,
+      "requires": {
+        "vl-ui-core": "^7.1.1"
       }
     },
     "vl-ui-icon": {
-      "version": "5.2.1",
-      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/vl-ui-icon/-/vl-ui-icon-5.2.1.tgz",
-      "integrity": "sha1-yVpYVjCp2QtaVhILTq4U6V+yqSE=",
+      "version": "5.2.2",
+      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/vl-ui-icon/-/vl-ui-icon-5.2.2.tgz",
+      "integrity": "sha1-8f+pkkXgbdYRMlkYTz3iCexw3lc=",
       "dev": true,
       "requires": {
-        "vl-ui-core": "^7.0.1"
+        "vl-ui-core": "^7.1.1"
       }
     },
     "vl-ui-input-addon": {
-      "version": "3.1.7",
-      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/vl-ui-input-addon/-/vl-ui-input-addon-3.1.7.tgz",
-      "integrity": "sha1-m6h9s4d/xrnHQvVRfFn3xYTWZlo=",
+      "version": "3.1.8",
+      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/vl-ui-input-addon/-/vl-ui-input-addon-3.1.8.tgz",
+      "integrity": "sha1-qQca0zfwjrWPNAwfIrx6kxjCFfk=",
       "dev": true,
       "requires": {
-        "vl-ui-core": "^7.0.1"
+        "vl-ui-core": "^7.1.1"
       }
     },
     "vl-ui-input-field": {
-      "version": "3.2.7",
-      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/vl-ui-input-field/-/vl-ui-input-field-3.2.7.tgz",
-      "integrity": "sha1-Mz7eDLZvdI0Pao3cKQMfDJzs6po=",
+      "version": "3.2.8",
+      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/vl-ui-input-field/-/vl-ui-input-field-3.2.8.tgz",
+      "integrity": "sha1-wFax7sUcWXM3RNfDcbIUfHJu6l4=",
       "dev": true,
       "requires": {
-        "vl-ui-core": "^7.0.1",
-        "vl-ui-form-validation": "^3.4.0",
-        "vl-ui-pattern": "^1.0.6"
+        "vl-ui-core": "^7.1.1",
+        "vl-ui-form-validation": "^3.4.3",
+        "vl-ui-pattern": "^1.0.7"
       }
     },
     "vl-ui-input-group": {
-      "version": "4.0.6",
-      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/vl-ui-input-group/-/vl-ui-input-group-4.0.6.tgz",
-      "integrity": "sha1-V3XvJb+/OosMcw3iZsU/dxQ2Txk=",
+      "version": "4.0.7",
+      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/vl-ui-input-group/-/vl-ui-input-group-4.0.7.tgz",
+      "integrity": "sha1-kDLRWUyLDWRCZlhVCwCo/998R0Y=",
       "dev": true,
       "requires": {
-        "vl-ui-core": "^7.0.1"
+        "vl-ui-core": "^7.1.1"
       }
     },
     "vl-ui-link": {
-      "version": "4.0.7",
-      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/vl-ui-link/-/vl-ui-link-4.0.7.tgz",
-      "integrity": "sha1-k8hz/A8RugpcxHdjblG4k4cXcsY=",
+      "version": "4.0.8",
+      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/vl-ui-link/-/vl-ui-link-4.0.8.tgz",
+      "integrity": "sha1-OYT86YHHxxKZZYJX0Yt5jntwKk4=",
       "dev": true,
       "requires": {
-        "vl-ui-core": "^7.0.1"
+        "vl-ui-core": "^7.1.1"
       }
     },
     "vl-ui-pattern": {
-      "version": "1.0.6",
-      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/vl-ui-pattern/-/vl-ui-pattern-1.0.6.tgz",
-      "integrity": "sha1-fK/w0/feuvgotDtp8ABnYtLaxzk=",
+      "version": "1.1.0",
+      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/vl-ui-pattern/-/vl-ui-pattern-1.1.0.tgz",
+      "integrity": "sha1-JazXuJoW9TbLDaIdyRMq51wIjkM=",
       "dev": true,
       "requires": {
-        "@govflanders/vl-ui-pattern": "^3.11.5",
-        "vl-ui-core": "^7.0.1"
+        "@govflanders/vl-ui-pattern": "^3.12.3",
+        "vl-ui-core": "^7.1.1"
       }
     },
     "vl-ui-select": {
-      "version": "4.2.0",
-      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/vl-ui-select/-/vl-ui-select-4.2.0.tgz",
-      "integrity": "sha1-IhxagboxvUSGvzcXoKp0UCW5DMo=",
+      "version": "4.2.1",
+      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/vl-ui-select/-/vl-ui-select-4.2.1.tgz",
+      "integrity": "sha1-nWGpi7DBcQ3X8vyVg8rszznSeAU=",
       "dev": true,
       "requires": {
         "@govflanders/vl-ui-core": "^4.1.3",
         "@govflanders/vl-ui-select": "^3.12.3",
         "@govflanders/vl-ui-util": "^3.12.3",
-        "vl-ui-core": "^7.0.2",
-        "vl-ui-form-validation": "^3.4.0"
+        "vl-ui-core": "^7.1.1",
+        "vl-ui-form-validation": "^3.4.3"
       }
     },
     "vl-ui-template": {
-      "version": "3.1.1",
-      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/vl-ui-template/-/vl-ui-template-3.1.1.tgz",
-      "integrity": "sha1-2tmImlt94+/5e4pbTYP7uJYPC2c=",
+      "version": "3.1.2",
+      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/vl-ui-template/-/vl-ui-template-3.1.2.tgz",
+      "integrity": "sha1-i/oRXfDfCm0xDuWtW7CUxbmXK2Y=",
       "dev": true,
       "requires": {
-        "vl-ui-core": "^7.0.0"
+        "vl-ui-core": "^7.1.1"
       }
     },
     "vl-ui-titles": {
-      "version": "3.1.0",
-      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/vl-ui-titles/-/vl-ui-titles-3.1.0.tgz",
-      "integrity": "sha1-m++FV3mUKYItzakvmrJu3+RoQCc=",
+      "version": "3.1.1",
+      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/vl-ui-titles/-/vl-ui-titles-3.1.1.tgz",
+      "integrity": "sha1-Wxc5YsF3XMfjgITVK+HSVTeBavY=",
       "dev": true,
       "requires": {
-        "vl-ui-core": "^7.0.1"
+        "vl-ui-core": "^7.1.1"
       }
     },
     "vl-ui-util": {
-      "version": "5.3.7",
-      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/vl-ui-util/-/vl-ui-util-5.3.7.tgz",
-      "integrity": "sha1-UD1WGqhLtUi5xsMH8mh/OlMsA1U=",
+      "version": "5.3.10",
+      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/vl-ui-util/-/vl-ui-util-5.3.10.tgz",
+      "integrity": "sha1-ufH5SMiUzrjBdqM2Bz0UBWRLfLI=",
       "dev": true,
       "requires": {
+        "axe-webdriverjs": "^2.3.0",
         "browserstack-local": "^1.4.8",
-        "chai": "^4.2.0",
+        "chai": "^4.3.3",
         "chai-as-promised": "^7.1.1",
-        "chromedriver": "^87.0.0",
-        "eslint": "^7.10.0",
+        "chromedriver": "^89.0.0",
+        "eslint": "^7.21.0",
         "eslint-config-google": "^0.14.0",
         "eslint-plugin-html": "^6.1.0",
         "eslint-plugin-only-warn": "^1.0.2",
@@ -14989,20 +15190,20 @@
         "geckodriver": "^1.20.0",
         "http-server": "^0.12.3",
         "jsdom": "^16.4.0",
-        "luxon": "^1.25.0",
+        "luxon": "^1.26.0",
         "minify": "^5.1.1",
-        "mocha": "^8.1.3",
+        "mocha": "^8.3.0",
         "mocha-junit-reporter": "^2.0.0",
         "mocha-multi-reporters": "^1.1.7",
         "np": "^6.5.0",
         "replace": "^1.2.0",
-        "sass": "^1.26.11",
+        "sass": "^1.32.8",
         "selenium-standalone": "6.23.0",
         "selenium-webdriver": "^4.0.0-alpha.7",
-        "simple-git": "^2.20.1",
+        "simple-git": "^2.36.0",
         "sinon": "^9.1.0",
-        "terser": "^5.3.4",
-        "vl-ui-demo": "^1.3.0",
+        "terser": "^5.6.0",
+        "vl-ui-demo": "^1.3.3",
         "wct-browser-legacy": "^1.0.2",
         "wct-junit-reporter": "^1.0.0",
         "web-component-tester": "^6.9.2",
@@ -16084,6 +16285,19 @@
         "isexe": "^2.0.0"
       }
     },
+    "which-boxed-primitive": {
+      "version": "1.0.2",
+      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
+      "integrity": "sha1-E3V7yJsgmwSf5dhkMOIc9AqJqOY=",
+      "dev": true,
+      "requires": {
+        "is-bigint": "^1.0.1",
+        "is-boolean-object": "^1.1.0",
+        "is-number-object": "^1.0.4",
+        "is-string": "^1.0.5",
+        "is-symbol": "^1.0.3"
+      }
+    },
     "which-module": {
       "version": "2.0.0",
       "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/which-module/-/which-module-2.0.0.tgz",
@@ -16135,9 +16349,9 @@
           "dev": true
         },
         "string-width": {
-          "version": "4.2.0",
-          "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/string-width/-/string-width-4.2.0.tgz",
-          "integrity": "sha1-lSGCxGzHssMT0VluYjmSvRY7crU=",
+          "version": "4.2.2",
+          "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/string-width/-/string-width-4.2.2.tgz",
+          "integrity": "sha1-2v1PlVmnWFz7pSnGoKT3NIjr1MU=",
           "dev": true,
           "requires": {
             "emoji-regex": "^8.0.0",
@@ -16272,58 +16486,76 @@
       }
     },
     "workerpool": {
-      "version": "6.0.2",
-      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/workerpool/-/workerpool-6.0.2.tgz",
-      "integrity": "sha1-4kG0PY0DPxvrUseFEGlFYDnR1Dg=",
+      "version": "6.1.0",
+      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/workerpool/-/workerpool-6.1.0.tgz",
+      "integrity": "sha1-qOA4tMlFaVloUt56jqQiju/es3s=",
       "dev": true
     },
     "wrap-ansi": {
-      "version": "5.1.0",
-      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
-      "integrity": "sha1-H9H2cjXVttD+54EFYAG/tpTAOwk=",
+      "version": "7.0.0",
+      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha1-Z+FFz/UQpqaYS98RUpEdadLrnkM=",
       "dev": true,
       "requires": {
-        "ansi-styles": "^3.2.0",
-        "string-width": "^3.0.0",
-        "strip-ansi": "^5.0.0"
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
       },
       "dependencies": {
         "ansi-regex": {
-          "version": "4.1.0",
-          "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha1-i5+PCM8ay4Q3Vqg5yox+MWjFGZc=",
+          "version": "5.0.0",
+          "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha1-OIU59VF5vzkznIGvMKZU1p+Hy3U=",
           "dev": true
         },
-        "emoji-regex": {
-          "version": "7.0.3",
-          "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/emoji-regex/-/emoji-regex-7.0.3.tgz",
-          "integrity": "sha1-kzoEBShgyF6DwSJHnEdIqOTHIVY=",
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha1-7dgDYornHATIWuegkG7a00tkiTc=",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha1-wqCah6y95pVD3m9j+jmVyCbFNqI=",
           "dev": true
         },
         "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "version": "3.0.0",
+          "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha1-8Rb4Bk/pCz94RKOJl8C3UFEmnx0=",
           "dev": true
         },
         "string-width": {
-          "version": "3.1.0",
-          "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/string-width/-/string-width-3.1.0.tgz",
-          "integrity": "sha1-InZ74htirxCBV0MG9prFG2IgOWE=",
+          "version": "4.2.2",
+          "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/string-width/-/string-width-4.2.2.tgz",
+          "integrity": "sha1-2v1PlVmnWFz7pSnGoKT3NIjr1MU=",
           "dev": true,
           "requires": {
-            "emoji-regex": "^7.0.1",
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^5.1.0"
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.0"
           }
         },
         "strip-ansi": {
-          "version": "5.2.0",
-          "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/strip-ansi/-/strip-ansi-5.2.0.tgz",
-          "integrity": "sha1-jJpTb+tq/JYr36WxBKUJHBrZwK4=",
+          "version": "6.0.0",
+          "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha1-CxVx3XZpzNTz4G4U7x7tJiJa5TI=",
           "dev": true,
           "requires": {
-            "ansi-regex": "^4.1.0"
+            "ansi-regex": "^5.0.0"
           }
         }
       }
@@ -16346,9 +16578,9 @@
       }
     },
     "ws": {
-      "version": "7.4.2",
-      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/ws/-/ws-7.4.2.tgz",
-      "integrity": "sha1-eCEABI5U6zb+mEM2OrHGhnKyYd0=",
+      "version": "7.4.3",
+      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/ws/-/ws-7.4.3.tgz",
+      "integrity": "sha1-H5ZD3jSlQ7jtsSS9y8RXrlWm5c0=",
       "dev": true
     },
     "xdg-basedir": {
@@ -16400,9 +16632,9 @@
       "dev": true
     },
     "y18n": {
-      "version": "4.0.1",
-      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/y18n/-/y18n-4.0.1.tgz",
-      "integrity": "sha1-jbK4PDHF11CZu4kLI/MJSJHiR9Q=",
+      "version": "5.0.5",
+      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/y18n/-/y18n-5.0.5.tgz",
+      "integrity": "sha1-h2nsCNA7HqLfJQCs71YXQ7u5qxg=",
       "dev": true
     },
     "yallist": {
@@ -16438,41 +16670,6 @@
           "integrity": "sha1-OIU59VF5vzkznIGvMKZU1p+Hy3U=",
           "dev": true
         },
-        "ansi-styles": {
-          "version": "4.3.0",
-          "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/ansi-styles/-/ansi-styles-4.3.0.tgz",
-          "integrity": "sha1-7dgDYornHATIWuegkG7a00tkiTc=",
-          "dev": true,
-          "requires": {
-            "color-convert": "^2.0.1"
-          }
-        },
-        "cliui": {
-          "version": "7.0.4",
-          "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/cliui/-/cliui-7.0.4.tgz",
-          "integrity": "sha1-oCZe5lVHb8gHrqnfPfjfd4OAi08=",
-          "dev": true,
-          "requires": {
-            "string-width": "^4.2.0",
-            "strip-ansi": "^6.0.0",
-            "wrap-ansi": "^7.0.0"
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
-          "dev": true,
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha1-wqCah6y95pVD3m9j+jmVyCbFNqI=",
-          "dev": true
-        },
         "is-fullwidth-code-point": {
           "version": "3.0.0",
           "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -16480,9 +16677,9 @@
           "dev": true
         },
         "string-width": {
-          "version": "4.2.0",
-          "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/string-width/-/string-width-4.2.0.tgz",
-          "integrity": "sha1-lSGCxGzHssMT0VluYjmSvRY7crU=",
+          "version": "4.2.2",
+          "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/string-width/-/string-width-4.2.2.tgz",
+          "integrity": "sha1-2v1PlVmnWFz7pSnGoKT3NIjr1MU=",
           "dev": true,
           "requires": {
             "emoji-regex": "^8.0.0",
@@ -16498,41 +16695,14 @@
           "requires": {
             "ansi-regex": "^5.0.0"
           }
-        },
-        "wrap-ansi": {
-          "version": "7.0.0",
-          "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-          "integrity": "sha1-Z+FFz/UQpqaYS98RUpEdadLrnkM=",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.0.0",
-            "string-width": "^4.1.0",
-            "strip-ansi": "^6.0.0"
-          }
-        },
-        "y18n": {
-          "version": "5.0.5",
-          "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/y18n/-/y18n-5.0.5.tgz",
-          "integrity": "sha1-h2nsCNA7HqLfJQCs71YXQ7u5qxg=",
-          "dev": true
-        },
-        "yargs-parser": {
-          "version": "20.2.4",
-          "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/yargs-parser/-/yargs-parser-20.2.4.tgz",
-          "integrity": "sha1-tCiQ8UVmeW+Fro46JSkNIF8VSlQ=",
-          "dev": true
         }
       }
     },
     "yargs-parser": {
-      "version": "13.1.2",
-      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/yargs-parser/-/yargs-parser-13.1.2.tgz",
-      "integrity": "sha1-Ew8JcC667vJlDVTObj5XBvek+zg=",
-      "dev": true,
-      "requires": {
-        "camelcase": "^5.0.0",
-        "decamelize": "^1.2.0"
-      }
+      "version": "20.2.4",
+      "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/yargs-parser/-/yargs-parser-20.2.4.tgz",
+      "integrity": "sha1-tCiQ8UVmeW+Fro46JSkNIF8VSlQ=",
+      "dev": true
     },
     "yargs-unparser": {
       "version": "2.0.0",
@@ -16546,18 +16716,6 @@
         "is-plain-obj": "^2.1.0"
       },
       "dependencies": {
-        "camelcase": {
-          "version": "6.2.0",
-          "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/camelcase/-/camelcase-6.2.0.tgz",
-          "integrity": "sha1-kkr4gcnVJaydh/QNlk5c6pgqGAk=",
-          "dev": true
-        },
-        "decamelize": {
-          "version": "4.0.0",
-          "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/decamelize/-/decamelize-4.0.0.tgz",
-          "integrity": "sha1-qkcte/Zg6xXzSU79UxyrfypwmDc=",
-          "dev": true
-        },
         "is-plain-obj": {
           "version": "2.1.0",
           "resolved": "http://repo.omgeving.vlaanderen.be:80/artifactory/api/npm/acd-npm/is-plain-obj/-/is-plain-obj-2.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   },
   "dependencies": {
     "@govflanders/vl-ui-form-validation": "^4.0.6",
-    "vl-ui-core": "^7.1.1"
+    "vl-ui-core": "^7.2.0"
   },
   "peerDependencies": {
     "vl-ui-core": "^7.1.0"
@@ -46,13 +46,13 @@
   "devDependencies": {
     "@govflanders/vl-ui-core": "^4.1.3",
     "@govflanders/vl-ui-util": "^3.12.3",
-    "vl-ui-body": "^1.0.7",
-    "vl-ui-button": "^5.0.9",
-    "vl-ui-datepicker": "^3.2.4",
-    "vl-ui-form-grid": "^3.0.7",
-    "vl-ui-form-message": "^5.0.5",
-    "vl-ui-input-field": "^3.2.7",
-    "vl-ui-select": "^4.2.0",
+    "vl-ui-body": "^1.0.8",
+    "vl-ui-button": "^5.0.10",
+    "vl-ui-datepicker": "^3.2.5",
+    "vl-ui-form-grid": "^3.0.9",
+    "vl-ui-form-message": "^5.0.7",
+    "vl-ui-input-field": "^3.2.8",
+    "vl-ui-select": "^4.2.1",
     "vl-ui-util": "^5.3.8"
   }
 }

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "vl-ui-button": "^5.0.10",
     "vl-ui-datepicker": "^3.2.5",
     "vl-ui-form-grid": "^3.0.9",
-    "vl-ui-form-message": "^5.0.7",
+    "vl-ui-form-message": "milieuinfo/webcomponent-vl-ui-form-message#formValidationMessageIsHiddenAlsHetErrorIdAttribuutHeeft",
     "vl-ui-input-field": "^3.2.8",
     "vl-ui-select": "^4.2.1",
     "vl-ui-util": "^5.3.8"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vl-ui-form-validation",
-  "version": "3.4.3",
+  "version": "3.5.0",
   "description": "De formulier validatie verzekert dat bij het invullen van het formulier de input van de gebruiker geldig is.",
   "author": "DIDM",
   "license": "MIT",

--- a/test/e2e/components/vl-form-validation-form.js
+++ b/test/e2e/components/vl-form-validation-form.js
@@ -6,35 +6,35 @@ const {VlButton} = require('vl-ui-button').Test;
 const vlFormValidation = require('./vl-form-validation');
 
 class VlForm extends VlElement {
-  async getInputField(naam) {
-    return this._getInputField(naam);
+  async getInputField(id) {
+    return this._getInputField(id);
   }
 
-  async getSelect(naam) {
-    return this._getSelect(naam);
+  async getSelect(id) {
+    return this._getSelect(id);
   }
 
   async getDatepicker(naam) {
     return this._getDatepicker(naam);
   }
 
-  async submit(form) {
-    const button = await this._getSubmitButton(form);
+  async submit() {
+    const button = await this._getSubmitButton();
     await button.click();
   }
 
-  async _getSubmitButton(form) {
-    return new VlButton(this.driver, `#button-form${form}`);
+  async _getSubmitButton() {
+    return new VlButton(this.driver, `${this.selector} [is="vl-button"]`);
   }
 
-  async _getInputField(naam) {
-    const input = await new VlInputField(this.driver, `#input-${naam}`);
+  async _getInputField(id) {
+    const input = await new VlInputField(this.driver, `#${id}`);
     Object.assign(input, vlFormValidation);
     return input;
   }
 
-  async _getSelect(naam) {
-    const select = await new VlSelect(this.driver, `#select-${naam}`);
+  async _getSelect(id) {
+    const select = await new VlSelect(this.driver, `#${id}`);
     Object.assign(select, vlFormValidation);
     return select;
   }

--- a/test/e2e/components/vl-form-validation-form.js
+++ b/test/e2e/components/vl-form-validation-form.js
@@ -18,13 +18,13 @@ class VlForm extends VlElement {
     return this._getDatepicker(naam);
   }
 
-  async submit() {
-    const button = await this._getSubmitButton();
+  async submit(form) {
+    const button = await this._getSubmitButton(form);
     await button.click();
   }
 
-  async _getSubmitButton() {
-    return new VlButton(this.driver, '[is="vl-button"]');
+  async _getSubmitButton(form) {
+    return new VlButton(this.driver, `#button-form${form}`);
   }
 
   async _getInputField(naam) {

--- a/test/e2e/components/vl-form-validation-form.js
+++ b/test/e2e/components/vl-form-validation-form.js
@@ -28,13 +28,13 @@ class VlForm extends VlElement {
   }
 
   async _getInputField(id) {
-    const input = await new VlInputField(this.driver, `#${id}`);
+    const input = await new VlInputField(this.driver, `#input-${id}`);
     Object.assign(input, vlFormValidation);
     return input;
   }
 
   async _getSelect(id) {
-    const select = await new VlSelect(this.driver, `#${id}`);
+    const select = await new VlSelect(this.driver, `#select-${id}`);
     Object.assign(select, vlFormValidation);
     return select;
   }

--- a/test/e2e/form-validation.test.js
+++ b/test/e2e/form-validation.test.js
@@ -11,7 +11,7 @@ describe('vl-form-validation', async () => {
 
   it('als gebruiker zie ik een foutmelding als een verplicht veld niet is ingevuld in een form dat validatie doet', async () => {
     const formNr = 1;
-    const form = await vlFormValidationPage.getForm(formNr);
+    const form = await vlFormValidationPage.getFormMetErrorMessagesAlsAttribuut();
     const input = await form.getInputField('voornaam');
     await assert.eventually.isTrue(input.isRequired());
     await assert.eventually.isFalse(input.hasError());
@@ -26,7 +26,7 @@ describe('vl-form-validation', async () => {
 
   it('als gebruiker zie ik een foutmelding als een e-mailadres verkeerd geformatteerd is', async () => {
     const formNr = 1;
-    const form = await vlFormValidationPage.getForm(formNr);
+    const form = await vlFormValidationPage.getFormMetErrorMessagesAlsAttribuut();
     const input = await form.getInputField('email');
 
     await input.setValue('invalid@email');
@@ -40,7 +40,7 @@ describe('vl-form-validation', async () => {
 
   it('als gebruiker zie ik een foutmelding als een iban nummer niet gelding is', async () => {
     const formNr = 1;
-    const form = await vlFormValidationPage.getForm(formNr);
+    const form = await vlFormValidationPage.getFormMetErrorMessagesAlsAttribuut();
     const input = await form.getInputField('iban');
 
     await input.setValue('BE00 0000 0000 1212');
@@ -54,7 +54,7 @@ describe('vl-form-validation', async () => {
 
   it('als gebruiker zie ik een foutmelding als een telefoonnr niet geldig is', async () => {
     const formNr = 1;
-    const form = await vlFormValidationPage.getForm(formNr);
+    const form = await vlFormValidationPage.getFormMetErrorMessagesAlsAttribuut();
     const input = await form.getInputField('telefoon');
 
     await input.setValue('02 123 44 3');
@@ -68,7 +68,7 @@ describe('vl-form-validation', async () => {
 
   it('als gebruiker zie ik een foutmelding als een rijksregisternummer niet geldig is', async () => {
     const formNr = 1;
-    const form = await vlFormValidationPage.getForm(formNr);
+    const form = await vlFormValidationPage.getFormMetErrorMessagesAlsAttribuut();
     const input = await form.getInputField('rrn');
 
     const invalidRRN = ['93.05.18-223', '88.12.03-001.96', '00.20.01-053.56', '33.00.00-084.26', '00.00.00-001.27', '44.00.00-281.60'];
@@ -88,7 +88,7 @@ describe('vl-form-validation', async () => {
 
   it('als gebruiker zie ik een foutmelding als een uuid niet geldig is', async () => {
     const formNr = 1;
-    const form = await vlFormValidationPage.getForm(formNr);
+    const form = await vlFormValidationPage.getFormMetErrorMessagesAlsAttribuut();
     const input = await form.getInputField('uuid');
 
     const invalidUuids = ['abc', '1c6fa548-5eef-11ez-ae93-0242ac130002', '1c6fa548-5eef-11ez-ae93-0242ac130002a', '1c6fa5485eef11ezae930242ac130002a'];
@@ -108,7 +108,7 @@ describe('vl-form-validation', async () => {
 
   it('als gebruiker zie ik een foutmelding als een datum niet geldig is', async () => {
     const formNr = 1;
-    const form = await vlFormValidationPage.getForm(formNr);
+    const form = await vlFormValidationPage.getFormMetErrorMessagesAlsAttribuut();
     const input = await form.getInputField('datum');
 
     await input.setValue('29.02.2019');
@@ -122,7 +122,7 @@ describe('vl-form-validation', async () => {
 
   it('als gebruiker zie ik een foutmelding als er niets is geselecteerd uit een lijst', async () => {
     const formNr = 1;
-    const form = await vlFormValidationPage.getForm(formNr);
+    const form = await vlFormValidationPage.getFormMetErrorMessagesAlsAttribuut();
     const select = await form.getSelect('stad');
 
     await form.submit(formNr);
@@ -135,7 +135,7 @@ describe('vl-form-validation', async () => {
 
   it('als gebruiker zie ik een foutmelding als er geen datum is geselecteerd', async () => {
     const formNr = 1;
-    const form = await vlFormValidationPage.getForm(formNr);
+    const form = await vlFormValidationPage.getFormMetErrorMessagesAlsAttribuut();
     const datepicker = await form.getDatepicker('datum');
 
     await form.submit(formNr);
@@ -147,7 +147,7 @@ describe('vl-form-validation', async () => {
   });
 
   it('als gebruiker zie ik een foutmelding die gedefinieerd is in de error-placeholder als een verplicht veld niet is ingevuld', async () => {
-    const form = await vlFormValidationPage.getForm(4);
+    const form = await vlFormValidationPage.getFormMetErrorMessagesViaPlaceholder();
 
     const input = await form.getInputField('form4-voornaam');
     await assert.eventually.isTrue(input.isRequired());
@@ -164,7 +164,7 @@ describe('vl-form-validation', async () => {
 
   it('als gebruiker zie ik een foutmelding, die gedefinieerd is in de error-placeholder,  als een e-mailadres verkeerd geformatteerd is', async () => {
     const formNr = 4;
-    const form = await vlFormValidationPage.getForm(formNr);
+    const form = await vlFormValidationPage.getFormMetErrorMessagesViaPlaceholder();
     const input = await form.getInputField('form4-email');
 
     await input.setValue('invalid@email');
@@ -179,7 +179,7 @@ describe('vl-form-validation', async () => {
 
   it('als gebruiker zie ik een foutmelding, die gedefinieerd is in de error-placeholder, als een iban nummer niet gelding is', async () => {
     const formNr = 4;
-    const form = await vlFormValidationPage.getForm(formNr);
+    const form = await vlFormValidationPage.getFormMetErrorMessagesViaPlaceholder();
     const input = await form.getInputField('form4-iban');
 
     await input.setValue('BE00 0000 0000 1212');
@@ -193,7 +193,7 @@ describe('vl-form-validation', async () => {
 
   it('als gebruiker zie ik een foutmelding, die gedefinieerd is in de error-placeholder, als een telefoonnr niet geldig is', async () => {
     const formNr = 4;
-    const form = await vlFormValidationPage.getForm(formNr);
+    const form = await vlFormValidationPage.getFormMetErrorMessagesViaPlaceholder();
     const input = await form.getInputField('form4-telefoon');
 
     await input.setValue('02 123 44 3');
@@ -207,7 +207,7 @@ describe('vl-form-validation', async () => {
 
   it('als gebruiker zie ik een foutmelding, die gedefinieerd is in de error-placeholder, als een rijksregisternummer niet geldig is', async () => {
     const formNr = 4;
-    const form = await vlFormValidationPage.getForm(formNr);
+    const form = await vlFormValidationPage.getFormMetErrorMessagesViaPlaceholder();
     const input = await form.getInputField('form4-rrn');
 
     const invalidRRN = ['93.05.18-223', '88.12.03-001.96', '00.20.01-053.56', '33.00.00-084.26', '00.00.00-001.27', '44.00.00-281.60'];
@@ -228,7 +228,7 @@ describe('vl-form-validation', async () => {
 
   it('als gebruiker zie ik een foutmelding, die gedefinieerd is in de error-placeholder, als een datum niet geldig is', async () => {
     const formNr = 4;
-    const form = await vlFormValidationPage.getForm(formNr);
+    const form = await vlFormValidationPage.getFormMetErrorMessagesViaPlaceholder();
     const input = await form.getInputField('form4-datum');
 
     await input.setValue('29.02.2019');
@@ -242,7 +242,7 @@ describe('vl-form-validation', async () => {
 
   it('als gebruiker zie ik een foutmelding als er niets is geselecteerd uit een lijst', async () => {
     const formNr = 4;
-    const form = await vlFormValidationPage.getForm(formNr);
+    const form = await vlFormValidationPage.getFormMetErrorMessagesViaPlaceholder();
     const select = await form.getSelect('form4-stad');
 
     await form.submit(formNr);
@@ -255,7 +255,7 @@ describe('vl-form-validation', async () => {
 
   it('als gebruiker zie ik een foutmelding, die gedefinieerd is in de error-placeholder, als een uuid niet geldig is', async () => {
     const formNr = 4;
-    const form = await vlFormValidationPage.getForm(formNr);
+    const form = await vlFormValidationPage.getFormMetErrorMessagesViaPlaceholder();
     const input = await form.getInputField('form4-uuid');
 
     const invalidUuids = ['abc', '1c6fa548-5eef-11ez-ae93-0242ac130002', '1c6fa548-5eef-11ez-ae93-0242ac130002a', '1c6fa5485eef11ezae930242ac130002a'];

--- a/test/e2e/form-validation.test.js
+++ b/test/e2e/form-validation.test.js
@@ -11,7 +11,7 @@ describe('vl-form-validation', async () => {
 
   it('als gebruiker zie ik een foutmelding als een verplicht veld niet is ingevuld in een form dat validatie doet', async () => {
     const form = await vlFormValidationPage.getFormWithErrorMessageAttributes();
-    const input = await form.getInputField('input-voornaam');
+    const input = await form.getInputField('voornaam');
     await assert.eventually.isTrue(input.isRequired());
     await assert.eventually.isFalse(input.hasError());
 
@@ -25,7 +25,7 @@ describe('vl-form-validation', async () => {
 
   it('als gebruiker zie ik een foutmelding als een e-mailadres verkeerd geformatteerd is', async () => {
     const form = await vlFormValidationPage.getFormWithErrorMessageAttributes();
-    const input = await form.getInputField('input-email');
+    const input = await form.getInputField('email');
 
     await input.setValue('invalid@email');
     await form.submit();
@@ -38,7 +38,7 @@ describe('vl-form-validation', async () => {
 
   it('als gebruiker zie ik een foutmelding als een iban nummer niet gelding is', async () => {
     const form = await vlFormValidationPage.getFormWithErrorMessageAttributes();
-    const input = await form.getInputField('input-iban');
+    const input = await form.getInputField('iban');
 
     await input.setValue('BE00 0000 0000 1212');
     await form.submit();
@@ -51,7 +51,7 @@ describe('vl-form-validation', async () => {
 
   it('als gebruiker zie ik een foutmelding als een telefoonnr niet geldig is', async () => {
     const form = await vlFormValidationPage.getFormWithErrorMessageAttributes();
-    const input = await form.getInputField('input-telefoon');
+    const input = await form.getInputField('telefoon');
 
     await input.setValue('02 123 44 3');
     await form.submit();
@@ -64,7 +64,7 @@ describe('vl-form-validation', async () => {
 
   it('als gebruiker zie ik een foutmelding als een rijksregisternummer niet geldig is', async () => {
     const form = await vlFormValidationPage.getFormWithErrorMessageAttributes();
-    const input = await form.getInputField('input-rrn');
+    const input = await form.getInputField('rrn');
 
     const invalidRRN = ['93.05.18-223', '88.12.03-001.96', '00.20.01-053.56', '33.00.00-084.26', '00.00.00-001.27', '44.00.00-281.60'];
     for (rrn of invalidRRN) {
@@ -83,7 +83,7 @@ describe('vl-form-validation', async () => {
 
   it('als gebruiker zie ik een foutmelding als een uuid niet geldig is', async () => {
     const form = await vlFormValidationPage.getFormWithErrorMessageAttributes();
-    const input = await form.getInputField('input-uuid');
+    const input = await form.getInputField('uuid');
 
     const invalidUuids = ['abc', '1c6fa548-5eef-11ez-ae93-0242ac130002', '1c6fa548-5eef-11ez-ae93-0242ac130002a', '1c6fa5485eef11ezae930242ac130002a'];
     for (const uuid of invalidUuids) {
@@ -102,7 +102,7 @@ describe('vl-form-validation', async () => {
 
   it('als gebruiker zie ik een foutmelding als een datum niet geldig is', async () => {
     const form = await vlFormValidationPage.getFormWithErrorMessageAttributes();
-    const input = await form.getInputField('input-datum');
+    const input = await form.getInputField('datum');
 
     await input.setValue('29.02.2019');
     await form.submit();
@@ -115,7 +115,7 @@ describe('vl-form-validation', async () => {
 
   it('als gebruiker zie ik een foutmelding als er niets is geselecteerd uit een lijst', async () => {
     const form = await vlFormValidationPage.getFormWithErrorMessageAttributes();
-    const select = await form.getSelect('select-stad');
+    const select = await form.getSelect('stad');
 
     await form.submit();
     await assert.eventually.isTrue(select.hasError());
@@ -138,7 +138,7 @@ describe('vl-form-validation', async () => {
   });
 
   it('als gebruiker zie ik een foutmelding als er geen geheel getal is ingevuld', async () => {
-    const form = await vlFormValidationPage.getForm(1);
+    const form = await vlFormValidationPage.getFormWithErrorMessageAttributes(1);
     const input = await form.getInputField('integer');
     await assert.eventually.isTrue(input.isNumericalOnlyInteger());
 
@@ -159,7 +159,7 @@ describe('vl-form-validation', async () => {
   });
 
   it('als gebruiker zie ik een foutmelding als het gehele getal niet tussen het ingestelde bereik ligt', async () => {
-    const form = await vlFormValidationPage.getForm(1);
+    const form = await vlFormValidationPage.getFormWithErrorMessageAttributes(1);
     const input = await form.getInputField('integer');
     await assert.eventually.equal(input.getNumericalGreaterThanOrEqualTo(), '2');
     await assert.eventually.equal(input.getNumericalLessThanOrEqualTo(), '1000');
@@ -191,7 +191,7 @@ describe('vl-form-validation', async () => {
   });
 
   it('als gebruiker zie ik een foutmelding als er geen (komma)getal is ingevuld', async () => {
-    const form = await vlFormValidationPage.getForm(1);
+    const form = await vlFormValidationPage.getFormWithErrorMessageAttributes(1);
     const input = await form.getInputField('decimal');
     await assert.eventually.isFalse(input.isNumericalOnlyInteger());
 
@@ -208,7 +208,7 @@ describe('vl-form-validation', async () => {
   });
 
   it('als gebruiker zie ik een foutmelding als het kommagetal niet tussen het ingestelde bereik ligt', async () => {
-    const form = await vlFormValidationPage.getForm(1);
+    const form = await vlFormValidationPage.getFormWithErrorMessageAttributes(1);
     const input = await form.getInputField('decimal');
     await assert.eventually.equal(input.getNumericalGreaterThan(), '2.5');
     await assert.eventually.equal(input.getNumericalLessThan(), '15.4');
@@ -242,7 +242,7 @@ describe('vl-form-validation', async () => {
   it('als gebruiker zie ik een foutmelding die gedefinieerd is in de error-placeholder als een verplicht veld niet is ingevuld', async () => {
     const form = await vlFormValidationPage.getFormWithErrorMessageElements();
 
-    const input = await form.getInputField('input-voornaam-err-via-placeholder');
+    const input = await form.getInputField('voornaam-err-via-placeholder');
     await assert.eventually.isTrue(input.isRequired());
     await assert.eventually.isFalse(input.hasError());
 
@@ -256,7 +256,7 @@ describe('vl-form-validation', async () => {
 
   it('als gebruiker zie ik een foutmelding, die gedefinieerd is in de error-placeholder, als een e-mailadres verkeerd geformatteerd is', async () => {
     const form = await vlFormValidationPage.getFormWithErrorMessageElements();
-    const input = await form.getInputField('input-email-err-via-placeholder');
+    const input = await form.getInputField('email-err-via-placeholder');
 
     await input.setValue('invalid@email');
     await form.submit();
@@ -269,7 +269,7 @@ describe('vl-form-validation', async () => {
 
   it('als gebruiker zie ik een foutmelding, die gedefinieerd is in de error-placeholder, als een iban nummer niet gelding is', async () => {
     const form = await vlFormValidationPage.getFormWithErrorMessageElements();
-    const input = await form.getInputField('input-iban-err-via-placeholder');
+    const input = await form.getInputField('iban-err-via-placeholder');
 
     await input.setValue('BE00 0000 0000 1212');
     await form.submit();
@@ -282,7 +282,7 @@ describe('vl-form-validation', async () => {
 
   it('als gebruiker zie ik een foutmelding, die gedefinieerd is in de error-placeholder, als een telefoonnr niet geldig is', async () => {
     const form = await vlFormValidationPage.getFormWithErrorMessageElements();
-    const input = await form.getInputField('input-telefoon-err-via-placeholder');
+    const input = await form.getInputField('telefoon-err-via-placeholder');
 
     await input.setValue('02 123 44 3');
     await form.submit();
@@ -295,7 +295,7 @@ describe('vl-form-validation', async () => {
 
   it('als gebruiker zie ik een foutmelding, die gedefinieerd is in de error-placeholder, als een rijksregisternummer niet geldig is', async () => {
     const form = await vlFormValidationPage.getFormWithErrorMessageElements();
-    const input = await form.getInputField('input-rrn-err-via-placeholder');
+    const input = await form.getInputField('rrn-err-via-placeholder');
 
     const invalidRRN = ['93.05.18-223', '88.12.03-001.96', '00.20.01-053.56', '33.00.00-084.26', '00.00.00-001.27', '44.00.00-281.60'];
     for (rrn of invalidRRN) {
@@ -314,7 +314,7 @@ describe('vl-form-validation', async () => {
 
   it('als gebruiker zie ik een foutmelding, die gedefinieerd is in de error-placeholder, als een datum niet geldig is', async () => {
     const form = await vlFormValidationPage.getFormWithErrorMessageElements();
-    const input = await form.getInputField('input-datum-err-via-placeholder');
+    const input = await form.getInputField('datum-err-via-placeholder');
 
     await input.setValue('29.02.2019');
     await form.submit();
@@ -325,21 +325,9 @@ describe('vl-form-validation', async () => {
     await assert.eventually.isFalse(input.hasError());
   });
 
-  it('als gebruiker zie ik een foutmelding als er niets is geselecteerd uit een lijst', async () => {
-    const form = await vlFormValidationPage.getFormWithErrorMessageElements();
-    const select = await form.getSelect('select-stad-err-via-placeholder');
-
-    await form.submit();
-    await assert.eventually.isTrue(select.hasError());
-
-    await select.selectByIndex(1);
-    await form.submit();
-    await assert.eventually.isFalse(select.hasError());
-  });
-
   it('als gebruiker zie ik een foutmelding, die gedefinieerd is in de error-placeholder, als een uuid niet geldig is', async () => {
     const form = await vlFormValidationPage.getFormWithErrorMessageElements();
-    const input = await form.getInputField('input-uuid-err-via-placeholder');
+    const input = await form.getInputField('uuid-err-via-placeholder');
 
     const invalidUuids = ['abc', '1c6fa548-5eef-11ez-ae93-0242ac130002', '1c6fa548-5eef-11ez-ae93-0242ac130002a', '1c6fa5485eef11ezae930242ac130002a'];
     for (const uuid of invalidUuids) {

--- a/test/e2e/form-validation.test.js
+++ b/test/e2e/form-validation.test.js
@@ -10,130 +10,266 @@ describe('vl-form-validation', async () => {
   });
 
   it('als gebruiker zie ik een foutmelding als een verplicht veld niet is ingevuld in een form dat validatie doet', async () => {
-    const form = await vlFormValidationPage.getForm(1);
+    const formNr = 1;
+    const form = await vlFormValidationPage.getForm(formNr);
     const input = await form.getInputField('voornaam');
     await assert.eventually.isTrue(input.isRequired());
     await assert.eventually.isFalse(input.hasError());
 
-    await form.submit();
+    await form.submit(formNr);
     await assert.eventually.isTrue(input.hasError());
 
     await input.setValue('Tom');
-    await form.submit();
+    await form.submit(formNr);
     await assert.eventually.isFalse(input.hasError());
   });
 
   it('als gebruiker zie ik een foutmelding als een e-mailadres verkeerd geformatteerd is', async () => {
-    const form = await vlFormValidationPage.getForm(1);
+    const formNr = 1;
+    const form = await vlFormValidationPage.getForm(formNr);
     const input = await form.getInputField('email');
 
     await input.setValue('invalid@email');
-    await form.submit();
+    await form.submit(formNr);
     await assert.eventually.isTrue(input.hasError());
 
     await input.setValue('valid@email.be');
-    await form.submit();
+    await form.submit(formNr);
     await assert.eventually.isFalse(input.hasError());
   });
 
   it('als gebruiker zie ik een foutmelding als een iban nummer niet gelding is', async () => {
-    const form = await vlFormValidationPage.getForm(1);
+    const formNr = 1;
+    const form = await vlFormValidationPage.getForm(formNr);
     const input = await form.getInputField('iban');
 
     await input.setValue('BE00 0000 0000 1212');
-    await form.submit();
+    await form.submit(formNr);
     await assert.eventually.isTrue(input.hasError());
 
     await input.setValue('BE19 0000 0000 1212');
-    await form.submit();
+    await form.submit(formNr);
     await assert.eventually.isFalse(input.hasError());
   });
 
   it('als gebruiker zie ik een foutmelding als een telefoonnr niet geldig is', async () => {
-    const form = await vlFormValidationPage.getForm(1);
+    const formNr = 1;
+    const form = await vlFormValidationPage.getForm(formNr);
     const input = await form.getInputField('telefoon');
 
     await input.setValue('02 123 44 3');
-    await form.submit();
+    await form.submit(formNr);
     await assert.eventually.isTrue(input.hasError());
 
     await input.setValue('02 222 22 22');
-    await form.submit();
+    await form.submit(formNr);
     await assert.eventually.isFalse(input.hasError());
   });
 
   it('als gebruiker zie ik een foutmelding als een rijksregisternummer niet geldig is', async () => {
-    const form = await vlFormValidationPage.getForm(1);
+    const formNr = 1;
+    const form = await vlFormValidationPage.getForm(formNr);
     const input = await form.getInputField('rrn');
 
     const invalidRRN = ['93.05.18-223', '88.12.03-001.96', '00.20.01-053.56', '33.00.00-084.26', '00.00.00-001.27', '44.00.00-281.60'];
     for (rrn of invalidRRN) {
       await input.setValue(rrn);
-      await form.submit();
+      await form.submit(formNr);
       await assert.eventually.isTrue(input.hasError());
     }
 
     const validRRN = ['93.05.18-223.61', '88.12.03-001.95', '00.20.01-053.57', '33.00.00-084.27', '00.00.00-001.28', '44.00.00-281.61'];
     for (rrn of validRRN) {
       await input.setValue(rrn);
-      await form.submit();
+      await form.submit(formNr);
       await assert.eventually.isFalse(input.hasError());
     }
   });
 
   it('als gebruiker zie ik een foutmelding als een uuid niet geldig is', async () => {
-    const form = await vlFormValidationPage.getForm(1);
+    const formNr = 1;
+    const form = await vlFormValidationPage.getForm(formNr);
     const input = await form.getInputField('uuid');
 
     const invalidUuids = ['abc', '1c6fa548-5eef-11ez-ae93-0242ac130002', '1c6fa548-5eef-11ez-ae93-0242ac130002a', '1c6fa5485eef11ezae930242ac130002a'];
     for (const uuid of invalidUuids) {
       await input.setValue(uuid);
-      await form.submit();
+      await form.submit(formNr);
       await assert.eventually.isTrue(input.hasError());
     }
 
     const validUuids = ['1c6fa548-5eef-11ea-ae93-0242ac130002', '12345678-ABCD-1234-ef00-0123456789ef'];
     for (const uuid of validUuids) {
       await input.setValue(uuid);
-      await form.submit();
+      await form.submit(formNr);
       await assert.eventually.isFalse(input.hasError());
     }
   });
 
   it('als gebruiker zie ik een foutmelding als een datum niet geldig is', async () => {
-    const form = await vlFormValidationPage.getForm(1);
+    const formNr = 1;
+    const form = await vlFormValidationPage.getForm(formNr);
     const input = await form.getInputField('datum');
 
     await input.setValue('29.02.2019');
-    await form.submit();
+    await form.submit(formNr);
     await assert.eventually.isTrue(input.hasError());
 
     await input.setValue('29.02.2020');
-    await form.submit();
+    await form.submit(formNr);
     await assert.eventually.isFalse(input.hasError());
   });
 
   it('als gebruiker zie ik een foutmelding als er niets is geselecteerd uit een lijst', async () => {
-    const form = await vlFormValidationPage.getForm(1);
+    const formNr = 1;
+    const form = await vlFormValidationPage.getForm(formNr);
     const select = await form.getSelect('stad');
 
-    await form.submit();
+    await form.submit(formNr);
     await assert.eventually.isTrue(select.hasError());
 
     await select.selectByIndex(1);
-    await form.submit();
+    await form.submit(formNr);
     await assert.eventually.isFalse(select.hasError());
   });
 
   it('als gebruiker zie ik een foutmelding als er geen datum is geselecteerd', async () => {
-    const form = await vlFormValidationPage.getForm(1);
+    const formNr = 1;
+    const form = await vlFormValidationPage.getForm(formNr);
     const datepicker = await form.getDatepicker('datum');
 
-    await form.submit();
+    await form.submit(formNr);
     await assert.eventually.isTrue(datepicker.hasError());
 
     await datepicker.selectDay(15);
-    await form.submit();
+    await form.submit(formNr);
     await assert.eventually.isFalse(datepicker.hasError());
+  });
+
+  it('als gebruiker zie ik een foutmelding die gedefinieerd is in de error-placeholder als een verplicht veld niet is ingevuld', async () => {
+    const form = await vlFormValidationPage.getForm(4);
+
+    const input = await form.getInputField('form4-voornaam');
+    await assert.eventually.isTrue(input.isRequired());
+    await assert.eventually.isFalse(input.hasError());
+
+    await form.submit(4);
+    await assert.eventually.isTrue(input.hasError());
+
+    await input.setValue('Tom');
+    await form.submit(4);
+    await assert.eventually.isFalse(input.hasError());
+  });
+
+
+  it('als gebruiker zie ik een foutmelding, die gedefinieerd is in de error-placeholder,  als een e-mailadres verkeerd geformatteerd is', async () => {
+    const formNr = 4;
+    const form = await vlFormValidationPage.getForm(formNr);
+    const input = await form.getInputField('form4-email');
+
+    await input.setValue('invalid@email');
+    await form.submit(formNr);
+    await assert.eventually.isTrue(input.hasError());
+
+    await input.setValue('valid@email.be');
+    await form.submit(formNr);
+    await assert.eventually.isFalse(input.hasError());
+  });
+
+
+  it('als gebruiker zie ik een foutmelding, die gedefinieerd is in de error-placeholder, als een iban nummer niet gelding is', async () => {
+    const formNr = 4;
+    const form = await vlFormValidationPage.getForm(formNr);
+    const input = await form.getInputField('form4-iban');
+
+    await input.setValue('BE00 0000 0000 1212');
+    await form.submit(formNr);
+    await assert.eventually.isTrue(input.hasError());
+
+    await input.setValue('BE19 0000 0000 1212');
+    await form.submit(formNr);
+    await assert.eventually.isFalse(input.hasError());
+  });
+
+  it('als gebruiker zie ik een foutmelding, die gedefinieerd is in de error-placeholder, als een telefoonnr niet geldig is', async () => {
+    const formNr = 4;
+    const form = await vlFormValidationPage.getForm(formNr);
+    const input = await form.getInputField('form4-telefoon');
+
+    await input.setValue('02 123 44 3');
+    await form.submit(formNr);
+    await assert.eventually.isTrue(input.hasError());
+
+    await input.setValue('02 222 22 22');
+    await form.submit(formNr);
+    await assert.eventually.isFalse(input.hasError());
+  });
+
+  it('als gebruiker zie ik een foutmelding, die gedefinieerd is in de error-placeholder, als een rijksregisternummer niet geldig is', async () => {
+    const formNr = 4;
+    const form = await vlFormValidationPage.getForm(formNr);
+    const input = await form.getInputField('form4-rrn');
+
+    const invalidRRN = ['93.05.18-223', '88.12.03-001.96', '00.20.01-053.56', '33.00.00-084.26', '00.00.00-001.27', '44.00.00-281.60'];
+    for (rrn of invalidRRN) {
+      await input.setValue(rrn);
+      await form.submit(formNr);
+      await assert.eventually.isTrue(input.hasError());
+    }
+
+    const validRRN = ['93.05.18-223.61', '88.12.03-001.95', '00.20.01-053.57', '33.00.00-084.27', '00.00.00-001.28', '44.00.00-281.61'];
+    for (rrn of validRRN) {
+      await input.setValue(rrn);
+      await form.submit(formNr);
+      await assert.eventually.isFalse(input.hasError());
+    }
+  });
+
+
+  it('als gebruiker zie ik een foutmelding, die gedefinieerd is in de error-placeholder, als een datum niet geldig is', async () => {
+    const formNr = 4;
+    const form = await vlFormValidationPage.getForm(formNr);
+    const input = await form.getInputField('form4-datum');
+
+    await input.setValue('29.02.2019');
+    await form.submit(formNr);
+    await assert.eventually.isTrue(input.hasError());
+
+    await input.setValue('29.02.2020');
+    await form.submit(formNr);
+    await assert.eventually.isFalse(input.hasError());
+  });
+
+  it('als gebruiker zie ik een foutmelding als er niets is geselecteerd uit een lijst', async () => {
+    const formNr = 4;
+    const form = await vlFormValidationPage.getForm(formNr);
+    const select = await form.getSelect('form4-stad');
+
+    await form.submit(formNr);
+    await assert.eventually.isTrue(select.hasError());
+
+    await select.selectByIndex(1);
+    await form.submit(formNr);
+    await assert.eventually.isFalse(select.hasError());
+  });
+
+  it('als gebruiker zie ik een foutmelding, die gedefinieerd is in de error-placeholder, als een uuid niet geldig is', async () => {
+    const formNr = 4;
+    const form = await vlFormValidationPage.getForm(formNr);
+    const input = await form.getInputField('form4-uuid');
+
+    const invalidUuids = ['abc', '1c6fa548-5eef-11ez-ae93-0242ac130002', '1c6fa548-5eef-11ez-ae93-0242ac130002a', '1c6fa5485eef11ezae930242ac130002a'];
+    for (const uuid of invalidUuids) {
+      await input.setValue(uuid);
+      await form.submit(formNr);
+      await assert.eventually.isTrue(input.hasError());
+    }
+
+    const validUuids = ['1c6fa548-5eef-11ea-ae93-0242ac130002', '12345678-ABCD-1234-ef00-0123456789ef'];
+    for (const uuid of validUuids) {
+      await input.setValue(uuid);
+      await form.submit(formNr);
+      await assert.eventually.isFalse(input.hasError());
+    }
   });
 });

--- a/test/e2e/form-validation.test.js
+++ b/test/e2e/form-validation.test.js
@@ -10,7 +10,7 @@ describe('vl-form-validation', async () => {
   });
 
   it('als gebruiker zie ik een foutmelding als een verplicht veld niet is ingevuld in een form dat validatie doet', async () => {
-    const form = await vlFormValidationPage.getFormMetErrorMessagesAlsAttribuut();
+    const form = await vlFormValidationPage.getFormWithErrorMessageAttributes();
     const input = await form.getInputField('input-voornaam');
     await assert.eventually.isTrue(input.isRequired());
     await assert.eventually.isFalse(input.hasError());
@@ -24,7 +24,7 @@ describe('vl-form-validation', async () => {
   });
 
   it('als gebruiker zie ik een foutmelding als een e-mailadres verkeerd geformatteerd is', async () => {
-    const form = await vlFormValidationPage.getFormMetErrorMessagesAlsAttribuut();
+    const form = await vlFormValidationPage.getFormWithErrorMessageAttributes();
     const input = await form.getInputField('input-email');
 
     await input.setValue('invalid@email');
@@ -37,7 +37,7 @@ describe('vl-form-validation', async () => {
   });
 
   it('als gebruiker zie ik een foutmelding als een iban nummer niet gelding is', async () => {
-    const form = await vlFormValidationPage.getFormMetErrorMessagesAlsAttribuut();
+    const form = await vlFormValidationPage.getFormWithErrorMessageAttributes();
     const input = await form.getInputField('input-iban');
 
     await input.setValue('BE00 0000 0000 1212');
@@ -50,7 +50,7 @@ describe('vl-form-validation', async () => {
   });
 
   it('als gebruiker zie ik een foutmelding als een telefoonnr niet geldig is', async () => {
-    const form = await vlFormValidationPage.getFormMetErrorMessagesAlsAttribuut();
+    const form = await vlFormValidationPage.getFormWithErrorMessageAttributes();
     const input = await form.getInputField('input-telefoon');
 
     await input.setValue('02 123 44 3');
@@ -63,7 +63,7 @@ describe('vl-form-validation', async () => {
   });
 
   it('als gebruiker zie ik een foutmelding als een rijksregisternummer niet geldig is', async () => {
-    const form = await vlFormValidationPage.getFormMetErrorMessagesAlsAttribuut();
+    const form = await vlFormValidationPage.getFormWithErrorMessageAttributes();
     const input = await form.getInputField('input-rrn');
 
     const invalidRRN = ['93.05.18-223', '88.12.03-001.96', '00.20.01-053.56', '33.00.00-084.26', '00.00.00-001.27', '44.00.00-281.60'];
@@ -82,7 +82,7 @@ describe('vl-form-validation', async () => {
   });
 
   it('als gebruiker zie ik een foutmelding als een uuid niet geldig is', async () => {
-    const form = await vlFormValidationPage.getFormMetErrorMessagesAlsAttribuut();
+    const form = await vlFormValidationPage.getFormWithErrorMessageAttributes();
     const input = await form.getInputField('input-uuid');
 
     const invalidUuids = ['abc', '1c6fa548-5eef-11ez-ae93-0242ac130002', '1c6fa548-5eef-11ez-ae93-0242ac130002a', '1c6fa5485eef11ezae930242ac130002a'];
@@ -101,7 +101,7 @@ describe('vl-form-validation', async () => {
   });
 
   it('als gebruiker zie ik een foutmelding als een datum niet geldig is', async () => {
-    const form = await vlFormValidationPage.getFormMetErrorMessagesAlsAttribuut();
+    const form = await vlFormValidationPage.getFormWithErrorMessageAttributes();
     const input = await form.getInputField('input-datum');
 
     await input.setValue('29.02.2019');
@@ -114,7 +114,7 @@ describe('vl-form-validation', async () => {
   });
 
   it('als gebruiker zie ik een foutmelding als er niets is geselecteerd uit een lijst', async () => {
-    const form = await vlFormValidationPage.getFormMetErrorMessagesAlsAttribuut();
+    const form = await vlFormValidationPage.getFormWithErrorMessageAttributes();
     const select = await form.getSelect('select-stad');
 
     await form.submit();
@@ -126,7 +126,7 @@ describe('vl-form-validation', async () => {
   });
 
   it('als gebruiker zie ik een foutmelding als er geen datum is geselecteerd', async () => {
-    const form = await vlFormValidationPage.getFormMetErrorMessagesAlsAttribuut();
+    const form = await vlFormValidationPage.getFormWithErrorMessageAttributes();
     const datepicker = await form.getDatepicker('datum');
 
     await form.submit();
@@ -138,7 +138,7 @@ describe('vl-form-validation', async () => {
   });
 
   it('als gebruiker zie ik een foutmelding die gedefinieerd is in de error-placeholder als een verplicht veld niet is ingevuld', async () => {
-    const form = await vlFormValidationPage.getFormMetErrorMessagesViaPlaceholder();
+    const form = await vlFormValidationPage.getFormWithErrorMessageElements();
 
     const input = await form.getInputField('input-voornaam-err-via-placeholder');
     await assert.eventually.isTrue(input.isRequired());
@@ -153,8 +153,8 @@ describe('vl-form-validation', async () => {
   });
 
 
-  it('als gebruiker zie ik een foutmelding, die gedefinieerd is in de error-placeholder,  als een e-mailadres verkeerd geformatteerd is', async () => {
-    const form = await vlFormValidationPage.getFormMetErrorMessagesViaPlaceholder();
+  it('als gebruiker zie ik een foutmelding, die gedefinieerd is in de error-placeholder, als een e-mailadres verkeerd geformatteerd is', async () => {
+    const form = await vlFormValidationPage.getFormWithErrorMessageElements();
     const input = await form.getInputField('input-email-err-via-placeholder');
 
     await input.setValue('invalid@email');
@@ -168,7 +168,7 @@ describe('vl-form-validation', async () => {
 
 
   it('als gebruiker zie ik een foutmelding, die gedefinieerd is in de error-placeholder, als een iban nummer niet gelding is', async () => {
-    const form = await vlFormValidationPage.getFormMetErrorMessagesViaPlaceholder();
+    const form = await vlFormValidationPage.getFormWithErrorMessageElements();
     const input = await form.getInputField('input-iban-err-via-placeholder');
 
     await input.setValue('BE00 0000 0000 1212');
@@ -181,7 +181,7 @@ describe('vl-form-validation', async () => {
   });
 
   it('als gebruiker zie ik een foutmelding, die gedefinieerd is in de error-placeholder, als een telefoonnr niet geldig is', async () => {
-    const form = await vlFormValidationPage.getFormMetErrorMessagesViaPlaceholder();
+    const form = await vlFormValidationPage.getFormWithErrorMessageElements();
     const input = await form.getInputField('input-telefoon-err-via-placeholder');
 
     await input.setValue('02 123 44 3');
@@ -194,7 +194,7 @@ describe('vl-form-validation', async () => {
   });
 
   it('als gebruiker zie ik een foutmelding, die gedefinieerd is in de error-placeholder, als een rijksregisternummer niet geldig is', async () => {
-    const form = await vlFormValidationPage.getFormMetErrorMessagesViaPlaceholder();
+    const form = await vlFormValidationPage.getFormWithErrorMessageElements();
     const input = await form.getInputField('input-rrn-err-via-placeholder');
 
     const invalidRRN = ['93.05.18-223', '88.12.03-001.96', '00.20.01-053.56', '33.00.00-084.26', '00.00.00-001.27', '44.00.00-281.60'];
@@ -214,7 +214,7 @@ describe('vl-form-validation', async () => {
 
 
   it('als gebruiker zie ik een foutmelding, die gedefinieerd is in de error-placeholder, als een datum niet geldig is', async () => {
-    const form = await vlFormValidationPage.getFormMetErrorMessagesViaPlaceholder();
+    const form = await vlFormValidationPage.getFormWithErrorMessageElements();
     const input = await form.getInputField('input-datum-err-via-placeholder');
 
     await input.setValue('29.02.2019');
@@ -227,7 +227,7 @@ describe('vl-form-validation', async () => {
   });
 
   it('als gebruiker zie ik een foutmelding als er niets is geselecteerd uit een lijst', async () => {
-    const form = await vlFormValidationPage.getFormMetErrorMessagesViaPlaceholder();
+    const form = await vlFormValidationPage.getFormWithErrorMessageElements();
     const select = await form.getSelect('select-stad-err-via-placeholder');
 
     await form.submit();
@@ -239,7 +239,7 @@ describe('vl-form-validation', async () => {
   });
 
   it('als gebruiker zie ik een foutmelding, die gedefinieerd is in de error-placeholder, als een uuid niet geldig is', async () => {
-    const form = await vlFormValidationPage.getFormMetErrorMessagesViaPlaceholder();
+    const form = await vlFormValidationPage.getFormWithErrorMessageElements();
     const input = await form.getInputField('input-uuid-err-via-placeholder');
 
     const invalidUuids = ['abc', '1c6fa548-5eef-11ez-ae93-0242ac130002', '1c6fa548-5eef-11ez-ae93-0242ac130002a', '1c6fa5485eef11ezae930242ac130002a'];

--- a/test/e2e/form-validation.test.js
+++ b/test/e2e/form-validation.test.js
@@ -10,265 +10,249 @@ describe('vl-form-validation', async () => {
   });
 
   it('als gebruiker zie ik een foutmelding als een verplicht veld niet is ingevuld in een form dat validatie doet', async () => {
-    const formNr = 1;
     const form = await vlFormValidationPage.getFormMetErrorMessagesAlsAttribuut();
-    const input = await form.getInputField('voornaam');
+    const input = await form.getInputField('input-voornaam');
     await assert.eventually.isTrue(input.isRequired());
     await assert.eventually.isFalse(input.hasError());
 
-    await form.submit(formNr);
+    await form.submit();
     await assert.eventually.isTrue(input.hasError());
 
     await input.setValue('Tom');
-    await form.submit(formNr);
+    await form.submit();
     await assert.eventually.isFalse(input.hasError());
   });
 
   it('als gebruiker zie ik een foutmelding als een e-mailadres verkeerd geformatteerd is', async () => {
-    const formNr = 1;
     const form = await vlFormValidationPage.getFormMetErrorMessagesAlsAttribuut();
-    const input = await form.getInputField('email');
+    const input = await form.getInputField('input-email');
 
     await input.setValue('invalid@email');
-    await form.submit(formNr);
+    await form.submit();
     await assert.eventually.isTrue(input.hasError());
 
     await input.setValue('valid@email.be');
-    await form.submit(formNr);
+    await form.submit();
     await assert.eventually.isFalse(input.hasError());
   });
 
   it('als gebruiker zie ik een foutmelding als een iban nummer niet gelding is', async () => {
-    const formNr = 1;
     const form = await vlFormValidationPage.getFormMetErrorMessagesAlsAttribuut();
-    const input = await form.getInputField('iban');
+    const input = await form.getInputField('input-iban');
 
     await input.setValue('BE00 0000 0000 1212');
-    await form.submit(formNr);
+    await form.submit();
     await assert.eventually.isTrue(input.hasError());
 
     await input.setValue('BE19 0000 0000 1212');
-    await form.submit(formNr);
+    await form.submit();
     await assert.eventually.isFalse(input.hasError());
   });
 
   it('als gebruiker zie ik een foutmelding als een telefoonnr niet geldig is', async () => {
-    const formNr = 1;
     const form = await vlFormValidationPage.getFormMetErrorMessagesAlsAttribuut();
-    const input = await form.getInputField('telefoon');
+    const input = await form.getInputField('input-telefoon');
 
     await input.setValue('02 123 44 3');
-    await form.submit(formNr);
+    await form.submit();
     await assert.eventually.isTrue(input.hasError());
 
     await input.setValue('02 222 22 22');
-    await form.submit(formNr);
+    await form.submit();
     await assert.eventually.isFalse(input.hasError());
   });
 
   it('als gebruiker zie ik een foutmelding als een rijksregisternummer niet geldig is', async () => {
-    const formNr = 1;
     const form = await vlFormValidationPage.getFormMetErrorMessagesAlsAttribuut();
-    const input = await form.getInputField('rrn');
+    const input = await form.getInputField('input-rrn');
 
     const invalidRRN = ['93.05.18-223', '88.12.03-001.96', '00.20.01-053.56', '33.00.00-084.26', '00.00.00-001.27', '44.00.00-281.60'];
     for (rrn of invalidRRN) {
       await input.setValue(rrn);
-      await form.submit(formNr);
+      await form.submit();
       await assert.eventually.isTrue(input.hasError());
     }
 
     const validRRN = ['93.05.18-223.61', '88.12.03-001.95', '00.20.01-053.57', '33.00.00-084.27', '00.00.00-001.28', '44.00.00-281.61'];
     for (rrn of validRRN) {
       await input.setValue(rrn);
-      await form.submit(formNr);
+      await form.submit();
       await assert.eventually.isFalse(input.hasError());
     }
   });
 
   it('als gebruiker zie ik een foutmelding als een uuid niet geldig is', async () => {
-    const formNr = 1;
     const form = await vlFormValidationPage.getFormMetErrorMessagesAlsAttribuut();
-    const input = await form.getInputField('uuid');
+    const input = await form.getInputField('input-uuid');
 
     const invalidUuids = ['abc', '1c6fa548-5eef-11ez-ae93-0242ac130002', '1c6fa548-5eef-11ez-ae93-0242ac130002a', '1c6fa5485eef11ezae930242ac130002a'];
     for (const uuid of invalidUuids) {
       await input.setValue(uuid);
-      await form.submit(formNr);
+      await form.submit();
       await assert.eventually.isTrue(input.hasError());
     }
 
     const validUuids = ['1c6fa548-5eef-11ea-ae93-0242ac130002', '12345678-ABCD-1234-ef00-0123456789ef'];
     for (const uuid of validUuids) {
       await input.setValue(uuid);
-      await form.submit(formNr);
+      await form.submit();
       await assert.eventually.isFalse(input.hasError());
     }
   });
 
   it('als gebruiker zie ik een foutmelding als een datum niet geldig is', async () => {
-    const formNr = 1;
     const form = await vlFormValidationPage.getFormMetErrorMessagesAlsAttribuut();
-    const input = await form.getInputField('datum');
+    const input = await form.getInputField('input-datum');
 
     await input.setValue('29.02.2019');
-    await form.submit(formNr);
+    await form.submit();
     await assert.eventually.isTrue(input.hasError());
 
     await input.setValue('29.02.2020');
-    await form.submit(formNr);
+    await form.submit();
     await assert.eventually.isFalse(input.hasError());
   });
 
   it('als gebruiker zie ik een foutmelding als er niets is geselecteerd uit een lijst', async () => {
-    const formNr = 1;
     const form = await vlFormValidationPage.getFormMetErrorMessagesAlsAttribuut();
-    const select = await form.getSelect('stad');
+    const select = await form.getSelect('select-stad');
 
-    await form.submit(formNr);
+    await form.submit();
     await assert.eventually.isTrue(select.hasError());
 
     await select.selectByIndex(1);
-    await form.submit(formNr);
+    await form.submit();
     await assert.eventually.isFalse(select.hasError());
   });
 
   it('als gebruiker zie ik een foutmelding als er geen datum is geselecteerd', async () => {
-    const formNr = 1;
     const form = await vlFormValidationPage.getFormMetErrorMessagesAlsAttribuut();
     const datepicker = await form.getDatepicker('datum');
 
-    await form.submit(formNr);
+    await form.submit();
     await assert.eventually.isTrue(datepicker.hasError());
 
     await datepicker.selectDay(15);
-    await form.submit(formNr);
+    await form.submit();
     await assert.eventually.isFalse(datepicker.hasError());
   });
 
   it('als gebruiker zie ik een foutmelding die gedefinieerd is in de error-placeholder als een verplicht veld niet is ingevuld', async () => {
     const form = await vlFormValidationPage.getFormMetErrorMessagesViaPlaceholder();
 
-    const input = await form.getInputField('form4-voornaam');
+    const input = await form.getInputField('input-voornaam-err-via-placeholder');
     await assert.eventually.isTrue(input.isRequired());
     await assert.eventually.isFalse(input.hasError());
 
-    await form.submit(4);
+    await form.submit();
     await assert.eventually.isTrue(input.hasError());
 
     await input.setValue('Tom');
-    await form.submit(4);
+    await form.submit();
     await assert.eventually.isFalse(input.hasError());
   });
 
 
   it('als gebruiker zie ik een foutmelding, die gedefinieerd is in de error-placeholder,  als een e-mailadres verkeerd geformatteerd is', async () => {
-    const formNr = 4;
     const form = await vlFormValidationPage.getFormMetErrorMessagesViaPlaceholder();
-    const input = await form.getInputField('form4-email');
+    const input = await form.getInputField('input-email-err-via-placeholder');
 
     await input.setValue('invalid@email');
-    await form.submit(formNr);
+    await form.submit();
     await assert.eventually.isTrue(input.hasError());
 
     await input.setValue('valid@email.be');
-    await form.submit(formNr);
+    await form.submit();
     await assert.eventually.isFalse(input.hasError());
   });
 
 
   it('als gebruiker zie ik een foutmelding, die gedefinieerd is in de error-placeholder, als een iban nummer niet gelding is', async () => {
-    const formNr = 4;
     const form = await vlFormValidationPage.getFormMetErrorMessagesViaPlaceholder();
-    const input = await form.getInputField('form4-iban');
+    const input = await form.getInputField('input-iban-err-via-placeholder');
 
     await input.setValue('BE00 0000 0000 1212');
-    await form.submit(formNr);
+    await form.submit();
     await assert.eventually.isTrue(input.hasError());
 
     await input.setValue('BE19 0000 0000 1212');
-    await form.submit(formNr);
+    await form.submit();
     await assert.eventually.isFalse(input.hasError());
   });
 
   it('als gebruiker zie ik een foutmelding, die gedefinieerd is in de error-placeholder, als een telefoonnr niet geldig is', async () => {
-    const formNr = 4;
     const form = await vlFormValidationPage.getFormMetErrorMessagesViaPlaceholder();
-    const input = await form.getInputField('form4-telefoon');
+    const input = await form.getInputField('input-telefoon-err-via-placeholder');
 
     await input.setValue('02 123 44 3');
-    await form.submit(formNr);
+    await form.submit();
     await assert.eventually.isTrue(input.hasError());
 
     await input.setValue('02 222 22 22');
-    await form.submit(formNr);
+    await form.submit();
     await assert.eventually.isFalse(input.hasError());
   });
 
   it('als gebruiker zie ik een foutmelding, die gedefinieerd is in de error-placeholder, als een rijksregisternummer niet geldig is', async () => {
-    const formNr = 4;
     const form = await vlFormValidationPage.getFormMetErrorMessagesViaPlaceholder();
-    const input = await form.getInputField('form4-rrn');
+    const input = await form.getInputField('input-rrn-err-via-placeholder');
 
     const invalidRRN = ['93.05.18-223', '88.12.03-001.96', '00.20.01-053.56', '33.00.00-084.26', '00.00.00-001.27', '44.00.00-281.60'];
     for (rrn of invalidRRN) {
       await input.setValue(rrn);
-      await form.submit(formNr);
+      await form.submit();
       await assert.eventually.isTrue(input.hasError());
     }
 
     const validRRN = ['93.05.18-223.61', '88.12.03-001.95', '00.20.01-053.57', '33.00.00-084.27', '00.00.00-001.28', '44.00.00-281.61'];
     for (rrn of validRRN) {
       await input.setValue(rrn);
-      await form.submit(formNr);
+      await form.submit();
       await assert.eventually.isFalse(input.hasError());
     }
   });
 
 
   it('als gebruiker zie ik een foutmelding, die gedefinieerd is in de error-placeholder, als een datum niet geldig is', async () => {
-    const formNr = 4;
     const form = await vlFormValidationPage.getFormMetErrorMessagesViaPlaceholder();
-    const input = await form.getInputField('form4-datum');
+    const input = await form.getInputField('input-datum-err-via-placeholder');
 
     await input.setValue('29.02.2019');
-    await form.submit(formNr);
+    await form.submit();
     await assert.eventually.isTrue(input.hasError());
 
     await input.setValue('29.02.2020');
-    await form.submit(formNr);
+    await form.submit();
     await assert.eventually.isFalse(input.hasError());
   });
 
   it('als gebruiker zie ik een foutmelding als er niets is geselecteerd uit een lijst', async () => {
-    const formNr = 4;
     const form = await vlFormValidationPage.getFormMetErrorMessagesViaPlaceholder();
-    const select = await form.getSelect('form4-stad');
+    const select = await form.getSelect('select-stad-err-via-placeholder');
 
-    await form.submit(formNr);
+    await form.submit();
     await assert.eventually.isTrue(select.hasError());
 
     await select.selectByIndex(1);
-    await form.submit(formNr);
+    await form.submit();
     await assert.eventually.isFalse(select.hasError());
   });
 
   it('als gebruiker zie ik een foutmelding, die gedefinieerd is in de error-placeholder, als een uuid niet geldig is', async () => {
-    const formNr = 4;
     const form = await vlFormValidationPage.getFormMetErrorMessagesViaPlaceholder();
-    const input = await form.getInputField('form4-uuid');
+    const input = await form.getInputField('input-uuid-err-via-placeholder');
 
     const invalidUuids = ['abc', '1c6fa548-5eef-11ez-ae93-0242ac130002', '1c6fa548-5eef-11ez-ae93-0242ac130002a', '1c6fa5485eef11ezae930242ac130002a'];
     for (const uuid of invalidUuids) {
       await input.setValue(uuid);
-      await form.submit(formNr);
+      await form.submit();
       await assert.eventually.isTrue(input.hasError());
     }
 
     const validUuids = ['1c6fa548-5eef-11ea-ae93-0242ac130002', '12345678-ABCD-1234-ef00-0123456789ef'];
     for (const uuid of validUuids) {
       await input.setValue(uuid);
-      await form.submit(formNr);
+      await form.submit();
       await assert.eventually.isFalse(input.hasError());
     }
   });

--- a/test/e2e/pages/vl-form-validation.page.js
+++ b/test/e2e/pages/vl-form-validation.page.js
@@ -9,6 +9,18 @@ class VlFormValidationPage extends Page {
   async load() {
     await super.load(Config.baseUrl + '/demo/vl-form-validation.html');
   }
+
+  async _getForm(id) {
+    return new VlForm(this.driver, `#${id}`);
+  }
+
+  async getFormMetErrorMessagesAlsAttribuut() {
+    return this._getForm('form-met-error-messages-als-attribuut');
+  }
+
+  async getFormMetErrorMessagesViaPlaceholder() {
+    return this._getForm('form-met-error-messages-via-placeholder');
+  }
 }
 
 module.exports = VlFormValidationPage;

--- a/test/e2e/pages/vl-form-validation.page.js
+++ b/test/e2e/pages/vl-form-validation.page.js
@@ -14,12 +14,12 @@ class VlFormValidationPage extends Page {
     return new VlForm(this.driver, `#${id}`);
   }
 
-  async getFormMetErrorMessagesAlsAttribuut() {
-    return this._getForm('form-met-error-messages-als-attribuut');
+  async getFormWithErrorMessageAttributes() {
+    return this._getForm('form-with-error-message-attributes');
   }
 
-  async getFormMetErrorMessagesViaPlaceholder() {
-    return this._getForm('form-met-error-messages-via-placeholder');
+  async getFormWithErrorMessageElements() {
+    return this._getForm('form-with-error-message-elements');
   }
 }
 

--- a/test/unit/vl-form-validation.test.html
+++ b/test/unit/vl-form-validation.test.html
@@ -38,7 +38,7 @@
           aria-required="true" 
           aria-invalid="true">
         </vl-form-validation-element>
-        <div class="error-message" data-vl-error-id="validation-naam-error">Error via inhoud</div>
+        <div class="error-message" data-vl-error-id="validation-naam-error">Error message via error placeholder</div>
         <button type="submit">Submit</button>
       </form>
     </template>
@@ -103,18 +103,6 @@
       });
 
       test('wanneer nog niets gevalideerd is, wordt geen tekstuele foutmelding getoond', () => {
-        const form = fixture('vl-form-validation-fixture');
-        const message = form.querySelector('.error-message');
-        assert.equal(message.innerText, '');
-      });
-
-      test('wanneer nog niets gevalideerd is, wordt geen tekstuele foutmelding getoond (zonder error message)', () => {
-        const form = fixture('vl-form-validation-zonder-error-message-fixture');
-        const message = form.querySelector('.error-message');
-        assert.equal(message.innerText, '');
-      });
-
-      test('wanneer nog niets gevalideerd is, wordt geen tekstuele foutmelding getoond', () => {
         [fixture('vl-form-validation-fixture'), fixture('vl-form-validation-zonder-error-message-fixture')].forEach((form) => {
           const message = form.querySelector('.error-message');
           assert.equal(message.innerText, '');
@@ -126,9 +114,23 @@
         const button = form.querySelector('button');
         button.click();
         const message = form.querySelector('.error-message');
-        console.log(message.innerText);
-        assert.equal(message.innerText, 'Error via inhoud');
+        assert.equal(message.innerText, 'Error message via error placeholder');
       });
+
+      // test('De foutmelding verdwijnt als de oorzaak is opgelost', () => {
+      //   const form = fixture('vl-form-validation-zonder-error-message-fixture');
+      //   const button = form.querySelector('button');
+      //   button.click();
+      //   let message = form.querySelector('.error-message');
+      //   assert.equal(message.innerText, 'Error message via error placeholder');
+
+      //   const inputElement = form.querySelector('vl-form-validation-element');
+      //   inputElement._inputElement.value = 'iets';
+      //   button.click();
+      //   debugger;
+      //   message = form.querySelector('.error-message');
+      //   assert.equal(message.innerText, '');
+      // });
     });
   </script>
 </body>

--- a/test/unit/vl-form-validation.test.html
+++ b/test/unit/vl-form-validation.test.html
@@ -38,7 +38,7 @@
           aria-required="true" 
           aria-invalid="true">
         </vl-form-validation-element>
-        <div class="error-message" data-vl-error-id="validation-naam-error">Veld 'Naam' is verplicht</div>
+        <div class="error-message" data-vl-error-id="validation-naam-error">Error via inhoud</div>
         <button type="submit">Submit</button>
       </form>
     </template>
@@ -115,14 +115,20 @@
       });
 
       test('wanneer nog niets gevalideerd is, wordt geen tekstuele foutmelding getoond', () => {
-        [fixture('vl-form-validation-fixture'), fixture('vl-form-validation-zonder-error-message-fixture')].forEach(form => {
+        [fixture('vl-form-validation-fixture'), fixture('vl-form-validation-zonder-error-message-fixture')].forEach((form) => {
           const message = form.querySelector('.error-message');
           assert.equal(message.innerText, '');
-        })
+        });
       });
 
-
-
+      test('er wordt ook een tekstuele foutmelding getoond bij validatie als de foutmelding enkel in de placeholder staat', () => {
+        const form = fixture('vl-form-validation-zonder-error-message-fixture');
+        const button = form.querySelector('button');
+        button.click();
+        const message = form.querySelector('.error-message');
+        console.log(message.innerText);
+        assert.equal(message.innerText, 'Error via inhoud');
+      });
     });
   </script>
 </body>

--- a/test/unit/vl-form-validation.test.html
+++ b/test/unit/vl-form-validation.test.html
@@ -28,6 +28,22 @@
     </template>
   </test-fixture>
 
+  <test-fixture id="vl-form-validation-zonder-error-message-fixture">
+    <template>
+      <form data-vl-validate-form>
+        <label class="vl-form__label" for="validation-naam">Naam</label>
+        <vl-form-validation-element name="validation-naam"
+          data-required="true" 
+          data-vl-error-placeholder="validation-naam-error" 
+          aria-required="true" 
+          aria-invalid="true">
+        </vl-form-validation-element>
+        <div class="error-message" data-vl-error-id="validation-naam-error">Veld 'Naam' is verplicht</div>
+        <button type="submit">Submit</button>
+      </form>
+    </template>
+  </test-fixture>
+
   <script type="module">
     import {vlFormValidation} from '../../src/vl-form-validation.js';
 
@@ -85,6 +101,28 @@
         const message = form.querySelector('.error-message');
         assert.notEqual(message.innerText, '');
       });
+
+      test('wanneer nog niets gevalideerd is, wordt geen tekstuele foutmelding getoond', () => {
+        const form = fixture('vl-form-validation-fixture');
+        const message = form.querySelector('.error-message');
+        assert.equal(message.innerText, '');
+      });
+
+      test('wanneer nog niets gevalideerd is, wordt geen tekstuele foutmelding getoond (zonder error message)', () => {
+        const form = fixture('vl-form-validation-zonder-error-message-fixture');
+        const message = form.querySelector('.error-message');
+        assert.equal(message.innerText, '');
+      });
+
+      test('wanneer nog niets gevalideerd is, wordt geen tekstuele foutmelding getoond', () => {
+        [fixture('vl-form-validation-fixture'), fixture('vl-form-validation-zonder-error-message-fixture')].forEach(form => {
+          const message = form.querySelector('.error-message');
+          assert.equal(message.innerText, '');
+        })
+      });
+
+
+
     });
   </script>
 </body>

--- a/test/unit/vl-form-validation.test.html
+++ b/test/unit/vl-form-validation.test.html
@@ -102,13 +102,6 @@
         assert.notEqual(message.innerText, '');
       });
 
-      test('wanneer nog niets gevalideerd is, wordt geen tekstuele foutmelding getoond', () => {
-        [fixture('vl-form-validation-fixture'), fixture('vl-form-validation-zonder-error-message-fixture')].forEach((form) => {
-          const message = form.querySelector('.error-message');
-          assert.equal(message.innerText, '');
-        });
-      });
-
       test('er wordt ook een tekstuele foutmelding getoond bij validatie als de foutmelding enkel in de placeholder staat', () => {
         const form = fixture('vl-form-validation-zonder-error-message-fixture');
         const button = form.querySelector('button');
@@ -116,21 +109,6 @@
         const message = form.querySelector('.error-message');
         assert.equal(message.innerText, 'Error message via error placeholder');
       });
-
-      // test('De foutmelding verdwijnt als de oorzaak is opgelost', () => {
-      //   const form = fixture('vl-form-validation-zonder-error-message-fixture');
-      //   const button = form.querySelector('button');
-      //   button.click();
-      //   let message = form.querySelector('.error-message');
-      //   assert.equal(message.innerText, 'Error message via error placeholder');
-
-      //   const inputElement = form.querySelector('vl-form-validation-element');
-      //   inputElement._inputElement.value = 'iets';
-      //   button.click();
-      //   debugger;
-      //   message = form.querySelector('.error-message');
-      //   assert.equal(message.innerText, '');
-      // });
     });
   </script>
 </body>


### PR DESCRIPTION
Als geen error-message attribuut is gegeven, wordt de inhoud van de placeholder getoond.

Door deze uitbreiding is het mogelijk om vl-proza-message te gaan combineren met de vl-form-validation webcomponent daar het voorlopig uitsluitend mogelijk is om foutmeldingen via HTML attributen te declareren.